### PR TITLE
feature6 feat: 관리자 패치노트 수정 웹 UI 구현

### DIFF
--- a/scripts/add-admin.ts
+++ b/scripts/add-admin.ts
@@ -1,0 +1,14 @@
+import { initFirebaseAdmin } from './lib/firebase-admin';
+
+async function addAdmin(): Promise<void> {
+  const db = initFirebaseAdmin();
+
+  await db.collection('metadata').doc('admins').set({
+    emails: ['bt01063767006@gmail.com'],
+    updatedAt: new Date().toISOString(),
+  });
+
+  console.log('관리자 등록 완료: bt01063767006@gmail.com');
+}
+
+addAdmin().catch(console.error);

--- a/src/app/admin/character/[name]/page.tsx
+++ b/src/app/admin/character/[name]/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { loadBalanceData, findCharacterByName, extractCharacters } from '@/lib/patch-data';
+import { AdminPatchList } from '@/components/admin/AdminPatchList';
+
+type PageProps = {
+  params: Promise<{ name: string }>;
+};
+
+export default async function AdminCharacterPage({ params }: PageProps): Promise<React.JSX.Element> {
+  const { name } = await params;
+  const decodedName = decodeURIComponent(name);
+
+  const balanceData = await loadBalanceData();
+  const characters = extractCharacters(balanceData);
+  const character = findCharacterByName(characters, decodedName);
+
+  if (!character) {
+    notFound();
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="mb-6">
+        <Link
+          href="/admin"
+          className="text-sm text-gray-400 hover:text-white transition-colors"
+        >
+          ← 캐릭터 목록으로
+        </Link>
+      </div>
+
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-white mb-2">{character.name}</h1>
+        <p className="text-gray-400">
+          총 {character.stats.totalPatches}개 패치 |{' '}
+          <span className="text-emerald-400">상향 {character.stats.buffCount}</span> |{' '}
+          <span className="text-rose-400">하향 {character.stats.nerfCount}</span> |{' '}
+          <span className="text-amber-400">조정 {character.stats.mixedCount}</span>
+        </p>
+      </div>
+
+      <AdminPatchList
+        characterName={character.name}
+        patches={character.patchHistory}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { AdminHeader } from '@/components/admin/AdminHeader';
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const { user, loading, isAdmin } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // 로딩 중이면 대기
+    if (loading) return;
+
+    // 로그인 페이지는 인증 체크 스킵
+    if (pathname === '/admin/login') return;
+
+    // 로그인되지 않은 경우 로그인 페이지로 리다이렉트
+    if (!user) {
+      router.push('/admin/login');
+      return;
+    }
+
+    // 관리자가 아닌 경우
+    if (!isAdmin) {
+      router.push('/admin/login');
+    }
+  }, [user, loading, isAdmin, pathname, router]);
+
+  // 로딩 중 표시
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--background)]">
+        <div className="text-gray-400">로딩 중...</div>
+      </div>
+    );
+  }
+
+  // 로그인 페이지는 헤더 없이 렌더링
+  if (pathname === '/admin/login') {
+    return <>{children}</>;
+  }
+
+  // 인증되지 않았거나 관리자가 아닌 경우
+  if (!user || !isAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--background)]">
+        <div className="text-center">
+          <div className="text-gray-400 mb-4">접근 권한이 없습니다.</div>
+          <a href="/admin/login" className="text-violet-400 hover:text-violet-300">
+            로그인 페이지로 이동
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  // 인증된 관리자
+  return (
+    <div className="min-h-screen bg-[var(--background)]">
+      <AdminHeader />
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { LoginForm } from '@/components/admin/LoginForm';
+
+export default function AdminLoginPage(): React.JSX.Element {
+  const { user, loading, isAdmin } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && user && isAdmin) {
+      router.push('/admin');
+    }
+  }, [user, loading, isAdmin, router]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--background)]">
+        <div className="text-gray-400">로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[var(--background)] px-4">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-white mb-2">관리자 로그인</h1>
+          <p className="text-gray-400">ER 패치 트래커 관리자 페이지</p>
+        </div>
+
+        <div className="bg-[var(--er-surface)] border border-[var(--er-border)] rounded-xl p-6">
+          <LoginForm />
+        </div>
+
+        <div className="mt-6 text-center">
+          <a href="/" className="text-sm text-gray-500 hover:text-gray-400 transition-colors">
+            ← 홈으로 돌아가기
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,23 @@
+import { loadBalanceData, extractCharacters } from '@/lib/patch-data';
+import { AdminCharacterList } from '@/components/admin/AdminCharacterList';
+
+export default async function AdminDashboardPage(): Promise<React.JSX.Element> {
+  const balanceData = await loadBalanceData();
+  const characters = extractCharacters(balanceData);
+
+  // 이름순 정렬
+  const sortedCharacters = [...characters].sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-white mb-2">캐릭터 패치 데이터 관리</h1>
+        <p className="text-gray-400">
+          수정할 캐릭터를 선택하세요. 총 {characters.length}명의 캐릭터가 있습니다.
+        </p>
+      </div>
+
+      <AdminCharacterList characters={sortedCharacters} />
+    </div>
+  );
+}

--- a/src/app/api/admin/characters/[name]/patches/[patchId]/route.ts
+++ b/src/app/api/admin/characters/[name]/patches/[patchId]/route.ts
@@ -1,0 +1,176 @@
+import { NextResponse } from 'next/server';
+import { adminAuth, db } from '@/lib/firebase-admin';
+import type { PatchEntry, Change, ChangeType } from '@/types/patch';
+
+type ChangeCategory = 'numeric' | 'mechanic' | 'added' | 'removed' | 'unknown';
+
+type ExtendedChange = Change & {
+  changeCategory?: ChangeCategory;
+};
+
+type ExtendedPatchEntry = Omit<PatchEntry, 'changes'> & {
+  changes: ExtendedChange[];
+};
+
+type CharacterData = {
+  name: string;
+  nameEn?: string;
+  stats: {
+    totalPatches: number;
+    buffCount: number;
+    nerfCount: number;
+    mixedCount: number;
+    currentStreak: {
+      type: ChangeType | null;
+      count: number;
+    };
+    maxBuffStreak: number;
+    maxNerfStreak: number;
+  };
+  patchHistory: ExtendedPatchEntry[];
+};
+
+type AdminsDoc = {
+  emails: string[];
+};
+
+async function verifyAdmin(authHeader: string | null): Promise<boolean> {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return false;
+  }
+
+  const idToken = authHeader.split('Bearer ')[1];
+
+  try {
+    const decodedToken = await adminAuth.verifyIdToken(idToken);
+    const email = decodedToken.email;
+
+    if (!email) return false;
+
+    const adminDoc = await db.collection('metadata').doc('admins').get();
+    if (!adminDoc.exists) return false;
+
+    const adminData = adminDoc.data() as AdminsDoc;
+    return adminData.emails?.includes(email) ?? false;
+  } catch {
+    return false;
+  }
+}
+
+// 통계 재계산
+function recalculateStats(
+  patchHistory: ExtendedPatchEntry[]
+): CharacterData['stats'] {
+  const stats: CharacterData['stats'] = {
+    totalPatches: patchHistory.length,
+    buffCount: 0,
+    nerfCount: 0,
+    mixedCount: 0,
+    currentStreak: { type: null, count: 0 },
+    maxBuffStreak: 0,
+    maxNerfStreak: 0,
+  };
+
+  if (patchHistory.length === 0) return stats;
+
+  // 날짜순 정렬 (오래된 것 먼저)
+  const chronological = [...patchHistory].sort(
+    (a, b) => new Date(a.patchDate).getTime() - new Date(b.patchDate).getTime()
+  );
+
+  let currentStreakType: ChangeType | null = null;
+  let currentStreakCount = 0;
+
+  for (const patch of chronological) {
+    if (patch.overallChange === 'buff') stats.buffCount++;
+    else if (patch.overallChange === 'nerf') stats.nerfCount++;
+    else stats.mixedCount++;
+
+    if (patch.overallChange === 'buff' || patch.overallChange === 'nerf') {
+      if (currentStreakType === patch.overallChange) {
+        currentStreakCount++;
+      } else {
+        if (currentStreakType === 'buff') {
+          stats.maxBuffStreak = Math.max(stats.maxBuffStreak, currentStreakCount);
+        } else if (currentStreakType === 'nerf') {
+          stats.maxNerfStreak = Math.max(stats.maxNerfStreak, currentStreakCount);
+        }
+        currentStreakType = patch.overallChange;
+        currentStreakCount = 1;
+      }
+    }
+  }
+
+  if (currentStreakType === 'buff') {
+    stats.maxBuffStreak = Math.max(stats.maxBuffStreak, currentStreakCount);
+  } else if (currentStreakType === 'nerf') {
+    stats.maxNerfStreak = Math.max(stats.maxNerfStreak, currentStreakCount);
+  }
+
+  stats.currentStreak.type = currentStreakType;
+  stats.currentStreak.count = currentStreakCount;
+
+  return stats;
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ name: string; patchId: string }> }
+): Promise<NextResponse> {
+  try {
+    // 관리자 권한 확인
+    const authHeader = request.headers.get('Authorization');
+    const isAdmin = await verifyAdmin(authHeader);
+
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { name, patchId } = await params;
+    const characterName = decodeURIComponent(name);
+    const patchIdNum = parseInt(patchId);
+
+    // 요청 body 파싱
+    const updatedPatch = (await request.json()) as ExtendedPatchEntry;
+
+    // Firestore에서 캐릭터 데이터 조회
+    const docRef = db.collection('characters').doc(characterName);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    const charData = doc.data() as CharacterData;
+
+    // 해당 패치 찾기
+    const patchIndex = charData.patchHistory.findIndex((p) => p.patchId === patchIdNum);
+    if (patchIndex === -1) {
+      return NextResponse.json({ error: 'Patch not found' }, { status: 404 });
+    }
+
+    // 패치 업데이트
+    charData.patchHistory[patchIndex] = {
+      ...charData.patchHistory[patchIndex],
+      ...updatedPatch,
+      patchId: patchIdNum, // patchId는 변경 불가
+    };
+
+    // 통계 재계산
+    charData.stats = recalculateStats(charData.patchHistory);
+
+    // Firestore 저장
+    await docRef.update({
+      patchHistory: charData.patchHistory,
+      stats: charData.stats,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'Patch updated successfully',
+    });
+  } catch (error) {
+    console.error('Patch update error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { adminAuth, db } from '@/lib/firebase-admin';
+
+type VerifyRequest = {
+  idToken: string;
+};
+
+type AdminsDoc = {
+  emails: string[];
+};
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    const { idToken } = (await request.json()) as VerifyRequest;
+
+    if (!idToken) {
+      return NextResponse.json({ error: 'ID Token is required' }, { status: 400 });
+    }
+
+    // Firebase Admin SDK로 토큰 검증
+    const decodedToken = await adminAuth.verifyIdToken(idToken);
+    const email = decodedToken.email;
+
+    if (!email) {
+      return NextResponse.json({ error: 'Email not found in token' }, { status: 400 });
+    }
+
+    // Firestore에서 관리자 목록 확인
+    const adminDoc = await db.collection('metadata').doc('admins').get();
+
+    if (!adminDoc.exists) {
+      // 관리자 문서가 없으면 관리자 아님
+      return NextResponse.json({ isAdmin: false, email });
+    }
+
+    const adminData = adminDoc.data() as AdminsDoc;
+    const isAdmin = adminData.emails?.includes(email) ?? false;
+
+    return NextResponse.json({ isAdmin, email });
+  } catch (error) {
+    console.error('Token verification error:', error);
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import { Providers } from '@/components/Providers';
 import './globals.css';
 
 const geistSans = Geist({
@@ -21,10 +22,12 @@ export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
-}>) {
+}>): React.JSX.Element {
   return (
     <html lang="ko">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { AuthProvider } from '@/contexts/AuthContext';
+import type { ReactNode } from 'react';
+
+type ProvidersProps = {
+  children: ReactNode;
+};
+
+export function Providers({ children }: ProvidersProps): React.JSX.Element {
+  return <AuthProvider>{children}</AuthProvider>;
+}

--- a/src/components/admin/AdminCharacterList.tsx
+++ b/src/components/admin/AdminCharacterList.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import Link from 'next/link';
+import type { Character } from '@/types/patch';
+
+type AdminCharacterListProps = {
+  characters: Character[];
+};
+
+export function AdminCharacterList({ characters }: AdminCharacterListProps): React.JSX.Element {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredCharacters = useMemo(() => {
+    if (!searchQuery.trim()) return characters;
+    const query = searchQuery.toLowerCase();
+    return characters.filter((char) => char.name.toLowerCase().includes(query));
+  }, [characters, searchQuery]);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="캐릭터 검색..."
+          className="w-full max-w-md px-4 py-2 bg-[var(--er-surface)] border border-[var(--er-border)] rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+        {filteredCharacters.map((character) => (
+          <Link
+            key={character.name}
+            href={`/admin/character/${encodeURIComponent(character.name)}`}
+            className="block p-4 bg-[var(--er-surface)] border border-[var(--er-border)] rounded-lg hover:border-violet-500/50 hover:bg-[var(--er-surface-hover)] transition-all"
+          >
+            <div className="text-white font-medium mb-1">{character.name}</div>
+            <div className="text-xs text-gray-400">
+              {character.stats.totalPatches}개 패치
+            </div>
+            <div className="flex gap-2 mt-2 text-xs">
+              <span className="text-emerald-400">+{character.stats.buffCount}</span>
+              <span className="text-rose-400">-{character.stats.nerfCount}</span>
+              <span className="text-amber-400">~{character.stats.mixedCount}</span>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {filteredCharacters.length === 0 && (
+        <div className="text-center py-12 text-gray-400">
+          검색 결과가 없습니다.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useAuth } from '@/contexts/AuthContext';
+import Link from 'next/link';
+
+export function AdminHeader(): React.JSX.Element {
+  const { user, signOut } = useAuth();
+
+  const handleSignOut = async (): Promise<void> => {
+    await signOut();
+  };
+
+  return (
+    <header className="bg-[var(--er-surface)] border-b border-[var(--er-border)]">
+      <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link href="/admin" className="text-xl font-bold text-white hover:text-violet-400 transition-colors">
+            관리자 페이지
+          </Link>
+          <span className="px-2 py-1 bg-violet-600/20 border border-violet-500/30 rounded text-xs text-violet-400">
+            ADMIN
+          </span>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <span className="text-sm text-gray-400">{user?.email}</span>
+          <Link
+            href="/"
+            className="text-sm text-gray-400 hover:text-white transition-colors"
+          >
+            홈으로
+          </Link>
+          <button
+            onClick={handleSignOut}
+            className="px-3 py-1.5 bg-rose-600/20 border border-rose-500/30 rounded text-sm text-rose-400 hover:bg-rose-600/30 transition-colors"
+          >
+            로그아웃
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/admin/AdminPatchList.tsx
+++ b/src/components/admin/AdminPatchList.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import type { PatchEntry, Change } from '@/types/patch';
+import { PatchEditForm } from './PatchEditForm';
+import { getChangeTypeLabel, getChangeTypeBgColor, formatDate } from '@/lib/patch-utils';
+
+type ChangeCategory = 'numeric' | 'mechanic' | 'added' | 'removed' | 'unknown';
+
+type ExtendedChange = Change & {
+  changeCategory?: ChangeCategory;
+};
+
+type ExtendedPatchEntry = Omit<PatchEntry, 'changes'> & {
+  changes: ExtendedChange[];
+};
+
+type AdminPatchListProps = {
+  characterName: string;
+  patches: ExtendedPatchEntry[];
+};
+
+export function AdminPatchList({ characterName, patches }: AdminPatchListProps): React.JSX.Element {
+  const [patchList, setPatchList] = useState<ExtendedPatchEntry[]>(patches);
+  const [editingPatch, setEditingPatch] = useState<ExtendedPatchEntry | null>(null);
+
+  const handleSave = (updatedPatch: ExtendedPatchEntry): void => {
+    setPatchList((prev) =>
+      prev.map((p) => (p.patchId === updatedPatch.patchId ? updatedPatch : p))
+    );
+    setEditingPatch(null);
+  };
+
+  return (
+    <div className="space-y-4">
+      {patchList.map((patch) => (
+        <div
+          key={patch.patchId}
+          className="p-4 bg-[var(--er-surface)] border border-[var(--er-border)] rounded-lg"
+        >
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-3">
+              <span
+                className={`px-2 py-1 rounded text-xs font-medium ${getChangeTypeBgColor(patch.overallChange)}`}
+              >
+                {getChangeTypeLabel(patch.overallChange)}
+              </span>
+              <span className="text-white font-medium">{patch.patchVersion}</span>
+              <span className="text-gray-400 text-sm">{formatDate(patch.patchDate)}</span>
+            </div>
+            <button
+              onClick={() => setEditingPatch(patch)}
+              className="px-3 py-1.5 bg-violet-600/20 border border-violet-500/30 rounded text-sm text-violet-400 hover:bg-violet-600/30 transition-colors"
+            >
+              수정
+            </button>
+          </div>
+
+          {patch.devComment && (
+            <p className="text-sm text-gray-400 mb-3 italic">&quot;{patch.devComment}&quot;</p>
+          )}
+
+          <div className="space-y-2">
+            {patch.changes.map((change, index) => (
+              <div
+                key={index}
+                className="text-sm p-2 bg-[#1a1c23] rounded flex items-start gap-2"
+              >
+                <span className="text-gray-500 shrink-0">{change.target}</span>
+                <span className="text-gray-400">{change.stat}:</span>
+                <span className="text-rose-400 line-through">{change.before}</span>
+                <span className="text-gray-500">→</span>
+                <span className="text-emerald-400">{change.after}</span>
+                {change.changeCategory && (
+                  <span className="ml-auto text-xs text-gray-500">
+                    [{change.changeCategory}]
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {editingPatch && (
+        <PatchEditForm
+          characterName={characterName}
+          patch={editingPatch}
+          onSave={handleSave}
+          onCancel={() => setEditingPatch(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/ChangeEditRow.tsx
+++ b/src/components/admin/ChangeEditRow.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { Change, ChangeType } from '@/types/patch';
+
+type ChangeCategory = 'numeric' | 'mechanic' | 'added' | 'removed' | 'unknown';
+
+type ExtendedChange = Change & {
+  changeCategory?: ChangeCategory;
+};
+
+type ChangeEditRowProps = {
+  change: ExtendedChange;
+  index: number;
+  onChange: (index: number, updated: ExtendedChange) => void;
+  onDelete: (index: number) => void;
+};
+
+const CHANGE_TYPES: { value: ChangeType; label: string; color: string }[] = [
+  { value: 'buff', label: '상향', color: 'text-emerald-400' },
+  { value: 'nerf', label: '하향', color: 'text-rose-400' },
+  { value: 'mixed', label: '조정', color: 'text-amber-400' },
+];
+
+const CHANGE_CATEGORIES: { value: ChangeCategory; label: string }[] = [
+  { value: 'numeric', label: '수치 변경' },
+  { value: 'mechanic', label: '메커니즘' },
+  { value: 'added', label: '효과 추가' },
+  { value: 'removed', label: '효과 제거' },
+  { value: 'unknown', label: '미분류' },
+];
+
+export function ChangeEditRow({
+  change,
+  index,
+  onChange,
+  onDelete,
+}: ChangeEditRowProps): React.JSX.Element {
+  const handleFieldChange = (field: keyof ExtendedChange, value: string): void => {
+    onChange(index, { ...change, [field]: value });
+  };
+
+  return (
+    <div className="p-4 bg-[#1a1c23] border border-[var(--er-border)] rounded-lg space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-gray-500">#{index + 1}</span>
+        <button
+          type="button"
+          onClick={() => onDelete(index)}
+          className="text-xs text-rose-400 hover:text-rose-300"
+        >
+          삭제
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">스킬/대상</label>
+          <input
+            type="text"
+            value={change.target}
+            onChange={(e) => handleFieldChange('target', e.target.value)}
+            className="w-full px-3 py-2 bg-[var(--er-surface)] border border-[var(--er-border)] rounded text-sm text-white"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">스탯</label>
+          <input
+            type="text"
+            value={change.stat}
+            onChange={(e) => handleFieldChange('stat', e.target.value)}
+            className="w-full px-3 py-2 bg-[var(--er-surface)] border border-[var(--er-border)] rounded text-sm text-white"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">변경 전</label>
+          <input
+            type="text"
+            value={change.before}
+            onChange={(e) => handleFieldChange('before', e.target.value)}
+            className="w-full px-3 py-2 bg-[var(--er-surface)] border border-[var(--er-border)] rounded text-sm text-white"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">변경 후</label>
+          <input
+            type="text"
+            value={change.after}
+            onChange={(e) => handleFieldChange('after', e.target.value)}
+            className="w-full px-3 py-2 bg-[var(--er-surface)] border border-[var(--er-border)] rounded text-sm text-white"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">변경 타입</label>
+          <select
+            value={change.changeType}
+            onChange={(e) => handleFieldChange('changeType', e.target.value)}
+            className="w-full px-3 py-2 bg-[var(--er-surface)] border border-[var(--er-border)] rounded text-sm text-white"
+          >
+            {CHANGE_TYPES.map((type) => (
+              <option key={type.value} value={type.value}>
+                {type.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">카테고리</label>
+          <select
+            value={change.changeCategory || 'unknown'}
+            onChange={(e) => handleFieldChange('changeCategory', e.target.value)}
+            className="w-full px-3 py-2 bg-[var(--er-surface)] border border-[var(--er-border)] rounded text-sm text-white"
+          >
+            {CHANGE_CATEGORIES.map((cat) => (
+              <option key={cat.value} value={cat.value}>
+                {cat.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/LoginForm.tsx
+++ b/src/components/admin/LoginForm.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+
+export function LoginForm(): React.JSX.Element {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const { signIn } = useAuth();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      await signIn(email, password);
+      router.push('/admin');
+    } catch (err) {
+      console.error('Login error:', err);
+      setError('로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-2">
+          이메일
+        </label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="w-full px-4 py-3 bg-[var(--er-surface)] border border-[var(--er-border)] rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+          placeholder="admin@example.com"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-2">
+          비밀번호
+        </label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          className="w-full px-4 py-3 bg-[var(--er-surface)] border border-[var(--er-border)] rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent"
+          placeholder="••••••••"
+        />
+      </div>
+
+      {error && (
+        <div className="p-3 bg-rose-500/10 border border-rose-500/30 rounded-lg text-rose-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full py-3 px-4 bg-violet-600 hover:bg-violet-700 disabled:bg-violet-800 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors"
+      >
+        {loading ? '로그인 중...' : '로그인'}
+      </button>
+    </form>
+  );
+}

--- a/src/components/admin/PatchEditForm.tsx
+++ b/src/components/admin/PatchEditForm.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useState } from 'react';
+import type { PatchEntry, Change, ChangeType } from '@/types/patch';
+import { ChangeEditRow } from './ChangeEditRow';
+import { useAuth } from '@/contexts/AuthContext';
+
+type ChangeCategory = 'numeric' | 'mechanic' | 'added' | 'removed' | 'unknown';
+
+type ExtendedChange = Change & {
+  changeCategory?: ChangeCategory;
+};
+
+type ExtendedPatchEntry = Omit<PatchEntry, 'changes'> & {
+  changes: ExtendedChange[];
+};
+
+type PatchEditFormProps = {
+  characterName: string;
+  patch: ExtendedPatchEntry;
+  onSave: (updatedPatch: ExtendedPatchEntry) => void;
+  onCancel: () => void;
+};
+
+const CHANGE_TYPES: { value: ChangeType; label: string }[] = [
+  { value: 'buff', label: '상향' },
+  { value: 'nerf', label: '하향' },
+  { value: 'mixed', label: '조정' },
+];
+
+export function PatchEditForm({
+  characterName,
+  patch,
+  onSave,
+  onCancel,
+}: PatchEditFormProps): React.JSX.Element {
+  const [editedPatch, setEditedPatch] = useState<ExtendedPatchEntry>(patch);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const { getIdToken } = useAuth();
+
+  const handleChangeUpdate = (index: number, updated: ExtendedChange): void => {
+    const newChanges = [...editedPatch.changes];
+    newChanges[index] = updated;
+    setEditedPatch({ ...editedPatch, changes: newChanges });
+  };
+
+  const handleChangeDelete = (index: number): void => {
+    const newChanges = editedPatch.changes.filter((_, i) => i !== index);
+    setEditedPatch({ ...editedPatch, changes: newChanges });
+  };
+
+  const handleAddChange = (): void => {
+    const newChange: ExtendedChange = {
+      target: '기본 스탯',
+      stat: '',
+      before: '',
+      after: '',
+      changeType: 'mixed',
+      changeCategory: 'unknown',
+    };
+    setEditedPatch({ ...editedPatch, changes: [...editedPatch.changes, newChange] });
+  };
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    setError('');
+    setSaving(true);
+
+    try {
+      const idToken = await getIdToken();
+      if (!idToken) {
+        throw new Error('인증 토큰을 가져올 수 없습니다.');
+      }
+
+      const response = await fetch(
+        `/api/admin/characters/${encodeURIComponent(characterName)}/patches/${patch.patchId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${idToken}`,
+          },
+          body: JSON.stringify(editedPatch),
+        }
+      );
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || '저장에 실패했습니다.');
+      }
+
+      onSave(editedPatch);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '저장에 실패했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-[var(--er-surface)] border border-[var(--er-border)] rounded-xl w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="p-4 border-b border-[var(--er-border)]">
+          <h2 className="text-lg font-bold text-white">
+            패치 수정 - {patch.patchVersion} ({patch.patchDate})
+          </h2>
+          <p className="text-sm text-gray-400">{characterName}</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-4 space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">전체 변경 타입</label>
+              <select
+                value={editedPatch.overallChange}
+                onChange={(e) =>
+                  setEditedPatch({ ...editedPatch, overallChange: e.target.value as ChangeType })
+                }
+                className="w-full px-3 py-2 bg-[#1a1c23] border border-[var(--er-border)] rounded text-white"
+              >
+                {CHANGE_TYPES.map((type) => (
+                  <option key={type.value} value={type.value}>
+                    {type.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">연속 횟수</label>
+              <input
+                type="number"
+                value={editedPatch.streak}
+                onChange={(e) =>
+                  setEditedPatch({ ...editedPatch, streak: parseInt(e.target.value) || 1 })
+                }
+                min={1}
+                className="w-full px-3 py-2 bg-[#1a1c23] border border-[var(--er-border)] rounded text-white"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm text-gray-400 mb-1">개발자 코멘트</label>
+            <textarea
+              value={editedPatch.devComment || ''}
+              onChange={(e) =>
+                setEditedPatch({ ...editedPatch, devComment: e.target.value || null })
+              }
+              rows={3}
+              className="w-full px-3 py-2 bg-[#1a1c23] border border-[var(--er-border)] rounded text-white resize-none"
+              placeholder="코멘트 없음"
+            />
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <label className="text-sm text-gray-400">
+                변경 사항 ({editedPatch.changes.length}개)
+              </label>
+              <button
+                type="button"
+                onClick={handleAddChange}
+                className="text-xs text-violet-400 hover:text-violet-300"
+              >
+                + 추가
+              </button>
+            </div>
+            <div className="space-y-3">
+              {editedPatch.changes.map((change, index) => (
+                <ChangeEditRow
+                  key={index}
+                  change={change}
+                  index={index}
+                  onChange={handleChangeUpdate}
+                  onDelete={handleChangeDelete}
+                />
+              ))}
+            </div>
+          </div>
+
+          {error && (
+            <div className="p-3 bg-rose-500/10 border border-rose-500/30 rounded text-rose-400 text-sm">
+              {error}
+            </div>
+          )}
+        </form>
+
+        <div className="p-4 border-t border-[var(--er-border)] flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="px-4 py-2 text-gray-400 hover:text-white transition-colors"
+          >
+            취소
+          </button>
+          <button
+            type="submit"
+            onClick={handleSubmit}
+            disabled={saving}
+            className="px-4 py-2 bg-violet-600 hover:bg-violet-700 disabled:bg-violet-800 text-white rounded-lg transition-colors"
+          >
+            {saving ? '저장 중...' : '저장'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import {
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signOut as firebaseSignOut,
+  type User,
+} from 'firebase/auth';
+import { auth } from '@/lib/firebase-client';
+
+type AuthContextType = {
+  user: User | null;
+  loading: boolean;
+  isAdmin: boolean;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  getIdToken: () => Promise<string | null>;
+};
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }): React.JSX.Element {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+      setUser(firebaseUser);
+
+      if (firebaseUser) {
+        // 관리자 권한 확인
+        try {
+          const idToken = await firebaseUser.getIdToken();
+          const response = await fetch('/api/auth/verify', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ idToken }),
+          });
+
+          if (response.ok) {
+            const data = await response.json();
+            setIsAdmin(data.isAdmin);
+          } else {
+            setIsAdmin(false);
+          }
+        } catch {
+          setIsAdmin(false);
+        }
+      } else {
+        setIsAdmin(false);
+      }
+
+      setLoading(false);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  const signIn = async (email: string, password: string): Promise<void> => {
+    await signInWithEmailAndPassword(auth, email, password);
+  };
+
+  const signOut = async (): Promise<void> => {
+    await firebaseSignOut(auth);
+    setIsAdmin(false);
+  };
+
+  const getIdToken = async (): Promise<string | null> => {
+    if (!user) return null;
+    return user.getIdToken();
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, isAdmin, signIn, signOut, getIdToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextType {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -1,10 +1,11 @@
 import { initializeApp, getApps, cert, type ServiceAccount } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
+import { getAuth } from 'firebase-admin/auth';
 import path from 'path';
 import { readFileSync } from 'fs';
 
 // 서버 전용 - Firebase Admin 초기화
-const initializeFirebaseAdmin = (): ReturnType<typeof getFirestore> => {
+const initializeFirebaseAdmin = (): void => {
   if (getApps().length === 0) {
     // 서비스 계정 키 파일 경로
     const serviceAccountPath = path.join(process.cwd(), 'firebase-service-account.json');
@@ -16,9 +17,13 @@ const initializeFirebaseAdmin = (): ReturnType<typeof getFirestore> => {
       credential: cert(serviceAccount),
     });
   }
-
-  return getFirestore();
 };
 
+// 초기화 실행
+initializeFirebaseAdmin();
+
 // Firestore 인스턴스 export
-export const db = initializeFirebaseAdmin();
+export const db = getFirestore();
+
+// Auth 인스턴스 export (토큰 검증용)
+export const adminAuth = getAuth();

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -1,0 +1,17 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+// 클라이언트용 Firebase 앱 초기화
+export const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
+
+// Firebase Auth 인스턴스
+export const auth = getAuth(app);


### PR DESCRIPTION
#6

- Firebase Auth 기반 관리자 인증 시스템 추가
- /admin 관리자 대시보드 페이지 생성
- /admin/login 로그인 페이지 생성
- /admin/character/[name] 캐릭터별 패치 수정 페이지 생성
- 패치 데이터 수정 API (/api/admin/characters/[name]/patches/[patchId])
- AuthContext로 전역 인증 상태 관리
- 관리자 권한은 Firestore metadata/admins 문서로 관리

