### PR TITLE
feature/18 fix: 날짜 포맷팅 hydration mismatch 수정

### DIFF
--- a/src/components/CharacterImage.tsx
+++ b/src/components/CharacterImage.tsx
@@ -23,15 +23,17 @@ export default function CharacterImage({
 }: Props): React.ReactElement {
   const [imageError, setImageError] = useState(false);
   const imagePath = getCharacterImagePathByKorean(name);
-  const hasImage = imagePath && !imageError;
   const initial = name.charAt(0);
   const { container, text } = sizeMap[size];
+
+  // 서버/클라이언트 초기 렌더링 일치를 위해 항상 이미지 시도
+  const showImage = imagePath && !imageError;
 
   return (
     <div
       className={`relative shrink-0 overflow-hidden rounded-xl border border-[#2a2d35] bg-[#1a1d24] ${container} ${className}`}
     >
-      {hasImage ? (
+      {showImage ? (
         <Image
           src={imagePath}
           alt={name}
@@ -39,6 +41,7 @@ export default function CharacterImage({
           sizes={size === 'lg' ? '112px' : size === 'md' ? '80px' : '48px'}
           className="object-cover"
           onError={() => setImageError(true)}
+          priority={size === 'lg'}
         />
       ) : (
         <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-violet-500/20 to-cyan-500/20">

--- a/src/lib/patch-utils.ts
+++ b/src/lib/patch-utils.ts
@@ -127,12 +127,11 @@ export const getChangeTypeBgColor = (type: ChangeType): string => {
   return colors[type];
 };
 
-// 순수 함수: 날짜 포맷팅
+// 순수 함수: 날짜 포맷팅 (서버/클라이언트 일관성을 위해 수동 포맷)
 export const formatDate = (dateStr: string): string => {
   const date = new Date(dateStr);
-  return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}년 ${month}월 ${day}일`;
 };


### PR DESCRIPTION

## 관련 이슈

closes #18
## 변경 사항

- toLocaleDateString이 서버/클라이언트에서 다른 결과 반환하는 문제
- 수동 포맷팅으로 변경하여 일관된 결과 보장
- React 418 에러 해결

## 변경 유형

- [x] 버그 수정
- [] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
