### PR TITLE
feature/21 fix: 패치노트 파싱 오류 수정

### DIFF
--- a/docs/work-logs/2026-01-04-패치파싱오류수정.md
+++ b/docs/work-logs/2026-01-04-패치파싱오류수정.md
@@ -1,0 +1,71 @@
+# 2026-01-04 패치 파싱 오류 수정
+
+## 상태: 완료
+
+## 목표
+
+GitHub Actions가 정상 실행되지만 새로운 패치노트가 Firebase에 반영되지 않는 문제 해결
+
+## 문제 분석
+
+### 발견된 문제점
+
+1. **쿠키 미설정으로 인한 영어 페이지 렌더링**
+   - puppeteer가 `locale=ko_KR` 쿠키 없이 접속하면 영어 페이지가 렌더링됨
+   - `parse-balance-changes.ts`에서 한국어 키워드 "실험체"를 찾지만, 영어 페이지에서는 "Character"로 표시됨
+
+2. **핫픽스 HTML 구조 미지원**
+   - 정규 패치: 캐릭터명이 `<p><span><strong>` 구조로 content 직접 자식
+   - 핫픽스: 캐릭터명이 `<ul><li><p><span><strong>` 구조로 UL 안에 위치
+   - 기존 로직이 content.children만 확인해서 핫픽스 구조 파싱 실패
+
+3. **P 태그 없는 LI 구조 미지원**
+   - 일부 핫픽스에서 `<li><span>` 구조 (P 태그 없음)
+   - 기존 로직이 `li > p > span`만 찾아서 실패
+
+## 해결책
+
+### 1. 쿠키 설정 추가 (세 스크립트 모두)
+
+```typescript
+await page.setCookie({
+  name: 'locale',
+  value: 'ko_KR',
+  domain: 'playeternalreturn.com',
+});
+```
+
+### 2. UL 내부 캐릭터명 탐색 로직 추가
+
+```typescript
+// 핫픽스 구조: UL > LI > P 안에 캐릭터명이 있을 수 있음
+if (firstP) {
+  const strong = firstP.querySelector('span > strong');
+  if (strong && spanText === strongText && /^[가-힣&\s]+$/.test(strongText)) {
+    // 캐릭터명 발견 시 처리
+  }
+}
+```
+
+### 3. P 태그 없는 LI 구조 지원
+
+```typescript
+if (descP) {
+  descSpan = descP.querySelector('span');
+} else {
+  // P 태그 없이 span이 직접 있는 경우
+  descSpan = descLi.querySelector(':scope > span');
+}
+```
+
+## 수정된 파일
+
+1. `scripts/crawl-patch-notes.ts` - 쿠키 설정 추가
+2. `scripts/validate-links.ts` - 쿠키 설정 추가
+3. `scripts/parse-balance-changes.ts` - 쿠키 설정 + 파싱 로직 개선
+
+## 테스트 결과
+
+- ✅ 3270 (9.6d 핫픽스) - 미르카 2개 변경사항 파싱 성공
+- ✅ 3229 (9.5c 핫픽스) - 미르카 변경사항 파싱 성공
+- ✅ 3242 (9.6 정규 패치) - 다수 캐릭터 + 코멘트 파싱 성공

--- a/scripts/crawl-patch-notes.ts
+++ b/scripts/crawl-patch-notes.ts
@@ -84,6 +84,13 @@ async function crawlNewPatchNotes(existingIds: Set<number>): Promise<{
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
   );
 
+  // 한국어 페이지 렌더링을 위한 쿠키 설정
+  await page.setCookie({
+    name: 'locale',
+    value: 'ko_KR',
+    domain: 'playeternalreturn.com',
+  });
+
   // 첫 페이지 로드 (쿠키/세션 설정용)
   console.log('패치노트 목록 페이지 접속...');
   await page.goto('https://playeternalreturn.com/posts/news?categoryPath=patchnote', {

--- a/scripts/validate-links.ts
+++ b/scripts/validate-links.ts
@@ -46,14 +46,11 @@ async function updatePatchNoteValidation(
   hasCharacterData: boolean
 ): Promise<void> {
   const db = initFirebaseAdmin();
-  await db
-    .collection('patchNotes')
-    .doc(id.toString())
-    .update({
-      status,
-      hasCharacterData,
-      validatedAt: new Date().toISOString(),
-    });
+  await db.collection('patchNotes').doc(id.toString()).update({
+    status,
+    hasCharacterData,
+    validatedAt: new Date().toISOString(),
+  });
 }
 
 async function validateLinks(): Promise<void> {
@@ -78,6 +75,13 @@ async function validateLinks(): Promise<void> {
   await page.setUserAgent(
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
   );
+
+  // 한국어 페이지 렌더링을 위한 쿠키 설정
+  await page.setCookie({
+    name: 'locale',
+    value: 'ko_KR',
+    domain: 'playeternalreturn.com',
+  });
 
   let successCount = 0;
   let failedCount = 0;


### PR DESCRIPTION
- 세 스크립트에 locale=ko_KR 쿠키 설정 추가 (영어 페이지 렌더링 방지)
- 핫픽스 HTML 구조 지원 (UL > LI > P 안의 캐릭터명 탐색)
- P 태그 없는 LI 구조 지원 (li > span 직접 탐색)


## 관련 이슈

closes #21

## 변경 사항

- github-action 업데이트 로직 오류 수정

## 변경 유형

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
