### PR TITLE
feature/31 [fix] EA 시즌 추가 및 UI 개선

### DIFF
--- a/docs/work-logs/2026-01-09-EA시즌추가.md
+++ b/docs/work-logs/2026-01-09-EA시즌추가.md
@@ -1,0 +1,89 @@
+# EA(Early Access) 시즌 추가
+
+- **날짜**: 2026-01-09
+- **브랜치**: feature/30
+- **상태**: 완료
+
+---
+
+## 문제 현상
+
+나타폰 캐릭터 페이지에서 patchDate가 "2023-07-05"인 패치(0.88.0)가 표시되지 않음.
+
+### 원인
+
+- 시즌 1 시작일: 2023-07-20
+- 해당 패치 날짜: 2023-07-05
+- `getSeasonByDate`가 시즌 1 이전 날짜에 대해 null 반환
+- `groupPatchesBySeason`에서 season이 null이면 그룹에 추가하지 않음
+
+---
+
+## 해결 방안
+
+시즌 1 이전 패치를 표시하기 위해 EA(Early Access) 시즌 추가
+
+---
+
+## 작업 내용
+
+### `src/lib/seasons.ts`
+
+1. SEASONS 배열에 EA 시즌 추가
+
+   ```typescript
+   {
+     number: 0,
+     name: 'Early Access',
+     nameKo: 'EA',
+     startPatch: '0.1',
+     startDate: '2020-01-01',
+     endPatch: '0.89',
+   }
+   ```
+
+2. `formatSeasonLabel` 수정
+   - EA(number: 0)는 "S0 EA" 대신 "EA"로만 표시
+
+### `src/app/character/[name]/page.tsx`
+
+- 시즌 헤더 배지: EA는 "S0" 대신 "EA" 표시
+  ```tsx
+  {
+    season.number === 0 ? 'EA' : `S${season.number}`;
+  }
+  ```
+
+---
+
+### EA 시즌 날짜 표시 제거
+
+- EA 시즌은 데이터 수집 제약으로 인해 날짜 범위 표시하지 않음
+- `"3개 패치"` 만 표시 (날짜 없음)
+
+```tsx
+{
+  season.number !== 0 && ` · ${season.startDate} ~ ${getSeasonEndDate(season) ?? '현재'}`;
+}
+```
+
+---
+
+### CharacterList에서 updatedAt 표시 제거
+
+- `metadata.balanceChanges.updatedAt`과 `latestPatch.crawledAt`이 별도 시점에 업데이트되어 혼란 발생
+- CharacterList에서 날짜 표시 제거, page.tsx의 latestPatch 정보만 사용
+
+**수정 파일:**
+
+- `src/components/CharacterList.tsx`: updatedAt prop 및 날짜 표시 UI 제거
+- `src/app/page.tsx`: CharacterList에 updatedAt prop 전달 제거
+
+---
+
+## 결과
+
+- 시즌 1 이전(2023-07-20 이전) 패치도 "EA" 시즌으로 그룹화되어 표시됨
+- 나타폰의 0.88.0 패치 등이 정상적으로 표시됨
+- EA 시즌은 날짜 없이 패치 개수만 표시
+- 메인 페이지에서 중복되던 날짜 표시 정리

--- a/src/app/character/[name]/page.tsx
+++ b/src/app/character/[name]/page.tsx
@@ -219,8 +219,9 @@ export default async function CharacterPage({ params }: Props): Promise<React.Re
                         {formatSeasonLabel(season)}
                       </h3>
                       <p className="text-xs text-zinc-500">
-                        {patches.length}개 패치 · {season.startDate} ~{' '}
-                        {getSeasonEndDate(season) ?? '현재'}
+                        {patches.length}개 패치
+                        {season.number !== 0 &&
+                          ` · ${season.startDate} ~ ${getSeasonEndDate(season) ?? '현재'}`}
                       </p>
                     </div>
                   </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -119,7 +119,7 @@ export default async function Home(): Promise<React.ReactElement> {
           <h2 id="character-list-heading" className="sr-only">
             실험체 목록
           </h2>
-          <CharacterList characters={characters} updatedAt={data.updatedAt} />
+          <CharacterList characters={characters} />
         </section>
       </main>
     </div>

--- a/src/components/CharacterList.tsx
+++ b/src/components/CharacterList.tsx
@@ -8,7 +8,6 @@ import FilterSort from './FilterSort';
 
 type Props = {
   characters: Character[];
-  updatedAt: string;
 };
 
 // 순수 함수: 상태 초기값 생성
@@ -19,7 +18,7 @@ const createInitialState = () => ({
   search: '',
 });
 
-export default function CharacterList({ characters, updatedAt }: Props): React.ReactElement {
+export default function CharacterList({ characters }: Props): React.ReactElement {
   const [state, setState] = useState(createInitialState);
 
   // 함수형 상태 업데이트
@@ -63,14 +62,6 @@ export default function CharacterList({ characters, updatedAt }: Props): React.R
     [updateState]
   );
 
-  const formattedDate = new Date(updatedAt).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-
   return (
     <div>
       {/* 헤더 정보 */}
@@ -100,17 +91,6 @@ export default function CharacterList({ characters, updatedAt }: Props): React.R
             </p>
             <p className="text-xs text-zinc-500">실험체 데이터</p>
           </div>
-        </div>
-        <div className="flex items-center gap-2 text-xs text-zinc-500">
-          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-          {formattedDate}
         </div>
       </div>
 

--- a/src/lib/seasons.ts
+++ b/src/lib/seasons.ts
@@ -15,6 +15,14 @@ export type Season = {
 
 export const SEASONS: Season[] = [
   {
+    number: 0,
+    name: 'Early Access',
+    nameKo: 'EA',
+    startPatch: '0.1',
+    startDate: '2020-01-01',
+    endPatch: '0.89',
+  },
+  {
     number: 1,
     name: 'Vacation',
     nameKo: '휴가',
@@ -187,6 +195,9 @@ export function getAllSeasonNumbers(): number[] {
  * 시즌 표시 문자열 생성
  */
 export function formatSeasonLabel(season: Season): string {
+  if (season.number === 0) {
+    return season.nameKo; // EA
+  }
   return `S${season.number} ${season.nameKo}`;
 }
 


### PR DESCRIPTION


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 관련 이슈

closes #31

## 변경 사항

- EA(Early Access) 시즌 추가로 시즌1 이전 패치 표시
- EA 시즌은 날짜 범위 표시하지 않음 (데이터 수집 제약)
- CharacterList에서 중복 날짜 표시 제거

## 변경 유형

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [x] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
