### PR TITLE
feature/29 [feat] 관리자 페이지 연속 재계산 기능 및 중복 패치 수정

### DIFF
--- a/docs/work-logs/2026-01-09-연속버프너프재계산.md
+++ b/docs/work-logs/2026-01-09-연속버프너프재계산.md
@@ -1,0 +1,57 @@
+# 연속 버프/너프 재계산 기능
+
+## 개요
+
+- **시작일**: 2026-01-09
+- **상태**: 완료
+- **관련 브랜치**: feature/29
+
+## 목표
+
+- [x] 캐릭터 상세 페이지에 연속(streak) 재계산 버튼 추가
+- [x] 개별 캐릭터의 streak 재계산 API 구현
+- [x] 빌드 테스트 통과
+- [x] 중복 패치 데이터 검사 및 수정
+
+## 배경
+
+크롤링 과정에서 연속 버프/너프(streak) 여부가 정확하지 않게 계산된 실험체들이 있음.
+이를 해결하기 위해 관리자가 개별 캐릭터의 streak을 재계산할 수 있는 기능 필요.
+
+## 진행 상황
+
+### 2026-01-09
+
+- 기존 코드 구조 분석 완료
+- 개별 캐릭터 재계산 API 구현: `/api/admin/characters/[name]/recalculate-streaks`
+- 캐릭터 상세 페이지(`AdminPatchList.tsx`)에 "연속 재계산" 버튼 추가
+- 빌드 테스트 통과
+- 중복 패치 데이터 발견 및 수정
+  - patchId 1654가 41개 캐릭터에서 2번씩 중복 저장됨
+  - `scripts/find-duplicate-patches.ts`: 중복 검사 스크립트 작성
+  - `scripts/fix-duplicate-patches.ts`: 중복 제거 스크립트 작성 및 실행
+  - 총 41개 중복 엔트리 제거 완료
+
+## 구현 내용
+
+### API 엔드포인트
+
+- **경로**: `POST /api/admin/characters/[name]/recalculate-streaks`
+- **기능**: 해당 캐릭터의 streak 및 stats 재계산
+- **인증**: Bearer token으로 관리자 권한 확인
+- **응답**: 성공/실패 메시지 및 업데이트된 stats
+
+### UI 버튼
+
+- 캐릭터 상세 페이지(`/admin/character/[name]`)에 "연속 재계산" 버튼 추가
+- 패치 목록 상단에 위치
+- 진행 중 로딩 상태 표시
+- 완료 시 페이지 새로고침으로 업데이트 반영
+- 실패 시 에러 메시지 표시
+
+## 관련 파일
+
+- `src/app/api/admin/characters/[name]/recalculate-streaks/route.ts` (신규)
+- `src/components/admin/AdminPatchList.tsx` (수정)
+- `scripts/find-duplicate-patches.ts` (신규) - 중복 패치 검사
+- `scripts/fix-duplicate-patches.ts` (신규) - 중복 패치 제거

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -17,14 +17,28 @@ npx tsx scripts/parse-balance-changes.ts
 
 ## 스크립트 목록
 
-| 스크립트 | 역할 |
-|----------|------|
-| `crawl-patch-notes.ts` | 공식 사이트에서 패치노트 크롤링 |
-| `validate-links.ts` | 패치노트 링크 검증, 캐릭터 데이터 유무 확인 |
-| `parse-balance-changes.ts` | 패치노트 HTML 파싱, 변경사항 추출 |
-| `fix-change-data.ts` | stat/before/after 구조 정리, changeCategory 추가 |
-| `fix-unknown-changes.ts` | unknown 카테고리 수동 수정 |
-| `upload-fixed-data.ts` | 로컬 JSON → Firestore 업로드 |
+### 크롤링/파싱
+
+| 스크립트                   | 역할                                        |
+| -------------------------- | ------------------------------------------- |
+| `crawl-patch-notes.ts`     | 공식 사이트에서 패치노트 크롤링             |
+| `validate-links.ts`        | 패치노트 링크 검증, 캐릭터 데이터 유무 확인 |
+| `parse-balance-changes.ts` | 패치노트 HTML 파싱, 변경사항 추출           |
+
+### 데이터 수정
+
+| 스크립트                    | 역할                                             |
+| --------------------------- | ------------------------------------------------ |
+| `fix-change-data.ts`        | stat/before/after 구조 정리, changeCategory 추가 |
+| `fix-unknown-changes.ts`    | unknown 카테고리 수동 수정                       |
+| `find-duplicate-patches.ts` | 중복된 patchId 검색 (검사용)                     |
+| `fix-duplicate-patches.ts`  | 중복된 patchId 제거                              |
+| `upload-fixed-data.ts`      | 로컬 JSON → Firestore 업로드                     |
+
+### 관리
+
+| 스크립트       | 역할               |
+| -------------- | ------------------ |
 | `add-admin.ts` | 관리자 이메일 등록 |
 
 ## 환경 설정
@@ -51,10 +65,31 @@ FIREBASE_SERVICE_ACCOUNT  # Secret에 JSON 문자열로 저장
 findFirstNumberIndexOutsideParens()
 ```
 
+## 중복 패치 검사/수정
+
+크롤링 오류로 인해 동일한 patchId가 중복 저장될 수 있음.
+
+```bash
+# 1. 중복 검사 (읽기 전용)
+npx tsx scripts/find-duplicate-patches.ts
+
+# 출력 예시:
+# [니키] 중복 발견:
+#   - patchId 1654: 2번 중복
+# 총 41개의 중복 엔트리 발견
+
+# 2. 중복 제거 (Firestore 직접 수정)
+npx tsx scripts/fix-duplicate-patches.ts
+
+# 출력 예시:
+# [니키] 1개 중복 제거
+# 총 41개의 중복 엔트리 제거 완료
+```
+
 ## 데이터 파일 (data/)
 
-| 파일 | 용도 |
-|------|------|
+| 파일                   | 용도                          |
+| ---------------------- | ----------------------------- |
 | `balance-changes.json` | 파싱된 캐릭터 데이터 (백업용) |
-| `fix-issues.json` | unknown 카테고리 항목 목록 |
-| `patch-notes.json` | 크롤링된 패치노트 (레거시) |
+| `fix-issues.json`      | unknown 카테고리 항목 목록    |
+| `patch-notes.json`     | 크롤링된 패치노트 (레거시)    |

--- a/scripts/find-duplicate-patches.ts
+++ b/scripts/find-duplicate-patches.ts
@@ -1,0 +1,72 @@
+/**
+ * 중복된 패치 엔트리를 찾는 스크립트
+ * Usage: npx tsx scripts/find-duplicate-patches.ts
+ */
+
+import { initFirebaseAdmin } from './lib/firebase-admin';
+
+type PatchEntry = {
+  patchId: number;
+  patchVersion: string;
+  patchDate: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+};
+
+type CharacterData = {
+  name: string;
+  patchHistory: PatchEntry[];
+};
+
+async function findDuplicatePatches(): Promise<void> {
+  console.log('중복 패치 검색 시작...\n');
+
+  const db = initFirebaseAdmin();
+  const charactersSnapshot = await db.collection('characters').get();
+  let totalDuplicates = 0;
+
+  for (const doc of charactersSnapshot.docs) {
+    const charData = doc.data() as CharacterData;
+    const characterName = doc.id;
+
+    // patchId별로 그룹화
+    const patchIdCounts = new Map<number, number>();
+    for (const patch of charData.patchHistory) {
+      const count = patchIdCounts.get(patch.patchId) || 0;
+      patchIdCounts.set(patch.patchId, count + 1);
+    }
+
+    // 중복된 patchId 찾기
+    const duplicates: number[] = [];
+    for (const [patchId, count] of patchIdCounts) {
+      if (count > 1) {
+        duplicates.push(patchId);
+      }
+    }
+
+    if (duplicates.length > 0) {
+      console.log(`\n[${characterName}] 중복 발견:`);
+      for (const patchId of duplicates) {
+        const count = patchIdCounts.get(patchId)!;
+        console.log(`  - patchId ${patchId}: ${count}번 중복`);
+        totalDuplicates += count - 1;
+      }
+    }
+  }
+
+  if (totalDuplicates === 0) {
+    console.log('중복된 패치가 없습니다.');
+  } else {
+    console.log(`\n총 ${totalDuplicates}개의 중복 엔트리 발견`);
+  }
+}
+
+findDuplicatePatches()
+  .then(() => {
+    console.log('\n완료');
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('오류:', error);
+    process.exit(1);
+  });

--- a/scripts/fix-duplicate-patches.ts
+++ b/scripts/fix-duplicate-patches.ts
@@ -1,0 +1,73 @@
+/**
+ * 중복된 패치 엔트리를 제거하는 스크립트
+ * Usage: npx tsx scripts/fix-duplicate-patches.ts
+ */
+
+import { initFirebaseAdmin } from './lib/firebase-admin';
+
+type PatchEntry = {
+  patchId: number;
+  patchVersion: string;
+  patchDate: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+};
+
+type CharacterData = {
+  name: string;
+  patchHistory: PatchEntry[];
+};
+
+async function fixDuplicatePatches(): Promise<void> {
+  console.log('중복 패치 제거 시작...\n');
+
+  const db = initFirebaseAdmin();
+  const charactersSnapshot = await db.collection('characters').get();
+  let totalFixed = 0;
+
+  for (const doc of charactersSnapshot.docs) {
+    const charData = doc.data() as CharacterData;
+    const characterName = doc.id;
+
+    // patchId별로 첫 번째 엔트리만 유지 (중복 제거)
+    const seenPatchIds = new Set<number>();
+    const uniquePatches: PatchEntry[] = [];
+    let duplicatesRemoved = 0;
+
+    for (const patch of charData.patchHistory) {
+      if (seenPatchIds.has(patch.patchId)) {
+        duplicatesRemoved++;
+      } else {
+        seenPatchIds.add(patch.patchId);
+        uniquePatches.push(patch);
+      }
+    }
+
+    if (duplicatesRemoved > 0) {
+      console.log(`[${characterName}] ${duplicatesRemoved}개 중복 제거`);
+
+      // Firestore 업데이트
+      await db.collection('characters').doc(characterName).update({
+        patchHistory: uniquePatches,
+      });
+
+      totalFixed += duplicatesRemoved;
+    }
+  }
+
+  if (totalFixed === 0) {
+    console.log('제거할 중복이 없습니다.');
+  } else {
+    console.log(`\n총 ${totalFixed}개의 중복 엔트리 제거 완료`);
+  }
+}
+
+fixDuplicatePatches()
+  .then(() => {
+    console.log('\n완료');
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('오류:', error);
+    process.exit(1);
+  });

--- a/src/app/api/admin/characters/[name]/recalculate-streaks/route.ts
+++ b/src/app/api/admin/characters/[name]/recalculate-streaks/route.ts
@@ -1,0 +1,213 @@
+import { NextResponse } from 'next/server';
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { adminAuth, db } from '@/lib/firebase-admin';
+import type { ChangeType } from '@/types/patch';
+
+type AdminsDoc = {
+  emails: string[];
+};
+
+type PatchEntryData = {
+  patchId: number;
+  patchVersion: string;
+  patchDate: string;
+  overallChange: ChangeType;
+  streak: number;
+  devComment: string | null;
+  changes: unknown[];
+};
+
+type CharacterData = {
+  name: string;
+  nameEn?: string;
+  stats: {
+    totalPatches: number;
+    buffCount: number;
+    nerfCount: number;
+    mixedCount: number;
+    currentStreak: {
+      type: ChangeType | null;
+      count: number;
+    };
+    maxBuffStreak: number;
+    maxNerfStreak: number;
+  };
+  patchHistory: PatchEntryData[];
+};
+
+async function verifyAdmin(authHeader: string | null): Promise<boolean> {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return false;
+  }
+
+  const idToken = authHeader.split('Bearer ')[1];
+
+  try {
+    const decodedToken = await adminAuth.verifyIdToken(idToken);
+    const email = decodedToken.email;
+
+    if (!email) return false;
+
+    const adminDoc = await db.collection('metadata').doc('admins').get();
+    if (!adminDoc.exists) return false;
+
+    const adminData = adminDoc.data() as AdminsDoc;
+    return adminData.emails?.includes(email) ?? false;
+  } catch {
+    return false;
+  }
+}
+
+// 전체 패치 히스토리의 streak 재계산
+function recalculateAllStreaks(patchHistory: PatchEntryData[]): PatchEntryData[] {
+  if (patchHistory.length === 0) return patchHistory;
+
+  // 날짜순 정렬 (오래된 것 먼저)
+  const chronological = [...patchHistory].sort(
+    (a, b) => new Date(a.patchDate).getTime() - new Date(b.patchDate).getTime()
+  );
+
+  let currentStreakType: ChangeType | null = null;
+  let currentStreakCount = 0;
+
+  for (let i = 0; i < chronological.length; i++) {
+    const patch = chronological[i];
+    if (patch.overallChange === 'buff' || patch.overallChange === 'nerf') {
+      if (currentStreakType === patch.overallChange) {
+        currentStreakCount++;
+      } else {
+        currentStreakType = patch.overallChange;
+        currentStreakCount = 1;
+      }
+      chronological[i] = { ...patch, streak: currentStreakCount };
+    } else {
+      currentStreakType = null;
+      currentStreakCount = 0;
+      chronological[i] = { ...patch, streak: 1 };
+    }
+  }
+
+  // 최신순(내림차순)으로 다시 정렬해서 반환
+  return chronological.sort(
+    (a, b) => new Date(b.patchDate).getTime() - new Date(a.patchDate).getTime()
+  );
+}
+
+// 통계 재계산
+function recalculateStats(patchHistory: PatchEntryData[]): CharacterData['stats'] {
+  const stats: CharacterData['stats'] = {
+    totalPatches: patchHistory.length,
+    buffCount: 0,
+    nerfCount: 0,
+    mixedCount: 0,
+    currentStreak: { type: null, count: 0 },
+    maxBuffStreak: 0,
+    maxNerfStreak: 0,
+  };
+
+  if (patchHistory.length === 0) return stats;
+
+  // 날짜순 정렬 (오래된 것 먼저)
+  const chronological = [...patchHistory].sort(
+    (a, b) => new Date(a.patchDate).getTime() - new Date(b.patchDate).getTime()
+  );
+
+  let currentStreakType: ChangeType | null = null;
+  let currentStreakCount = 0;
+
+  for (const patch of chronological) {
+    if (patch.overallChange === 'buff') stats.buffCount++;
+    else if (patch.overallChange === 'nerf') stats.nerfCount++;
+    else stats.mixedCount++;
+
+    if (patch.overallChange === 'buff' || patch.overallChange === 'nerf') {
+      if (currentStreakType === patch.overallChange) {
+        currentStreakCount++;
+      } else {
+        if (currentStreakType === 'buff') {
+          stats.maxBuffStreak = Math.max(stats.maxBuffStreak, currentStreakCount);
+        } else if (currentStreakType === 'nerf') {
+          stats.maxNerfStreak = Math.max(stats.maxNerfStreak, currentStreakCount);
+        }
+        currentStreakType = patch.overallChange;
+        currentStreakCount = 1;
+      }
+    } else {
+      if (currentStreakType === 'buff') {
+        stats.maxBuffStreak = Math.max(stats.maxBuffStreak, currentStreakCount);
+      } else if (currentStreakType === 'nerf') {
+        stats.maxNerfStreak = Math.max(stats.maxNerfStreak, currentStreakCount);
+      }
+      currentStreakType = null;
+      currentStreakCount = 0;
+    }
+  }
+
+  if (currentStreakType === 'buff') {
+    stats.maxBuffStreak = Math.max(stats.maxBuffStreak, currentStreakCount);
+  } else if (currentStreakType === 'nerf') {
+    stats.maxNerfStreak = Math.max(stats.maxNerfStreak, currentStreakCount);
+  }
+
+  stats.currentStreak.type = currentStreakType;
+  stats.currentStreak.count = currentStreakCount;
+
+  return stats;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> }
+): Promise<NextResponse> {
+  try {
+    // 관리자 권한 확인
+    const authHeader = request.headers.get('Authorization');
+    const isAdmin = await verifyAdmin(authHeader);
+
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { name } = await params;
+    const characterName = decodeURIComponent(name);
+
+    // Firestore에서 캐릭터 데이터 조회
+    const docRef = db.collection('characters').doc(characterName);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    const charData = doc.data() as CharacterData;
+
+    // streak 재계산
+    const updatedPatchHistory = recalculateAllStreaks(charData.patchHistory);
+
+    // 통계 재계산
+    const updatedStats = recalculateStats(updatedPatchHistory);
+
+    // Firestore 업데이트
+    await docRef.update({
+      patchHistory: updatedPatchHistory,
+      stats: updatedStats,
+    });
+
+    // 캐시 무효화
+    revalidateTag('balance-data', 'max');
+    revalidateTag('patch-notes-data', 'max');
+    revalidatePath('/');
+    revalidatePath('/admin');
+    revalidatePath(`/character/${encodeURIComponent(characterName)}`, 'page');
+    revalidatePath(`/admin/character/${encodeURIComponent(characterName)}`, 'page');
+
+    return NextResponse.json({
+      success: true,
+      message: `${characterName}의 연속 기록이 재계산되었습니다.`,
+      stats: updatedStats,
+    });
+  } catch (error) {
+    console.error('Streak recalculation error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION

## 관련 이슈

closes #29

## 변경 사항

- 캐릭터 상세 페이지에 연속(streak) 재계산 버튼 추가
- 개별 캐릭터 streak 재계산 API 구현
- 중복 패치 검사/수정 스크립트 추가
- patchId 1654 중복 데이터 41건 제거 완료

## 변경 유형

- [x] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
