### PR TITLE
Feature/42

### DIFF
--- a/docs/work-logs/2026-01-19-패치아이디표시.md
+++ b/docs/work-logs/2026-01-19-패치아이디표시.md
@@ -1,0 +1,21 @@
+# 패치 아이디 표시
+
+## 개요
+
+- **시작일**: 2026-01-19
+- **상태**: 완료
+- **관련 브랜치**: feature/42 (예정)
+
+## 목표
+
+- [x] 관리자 페이지 패치 목록에서 패치노트 ID도 함께 표시
+
+## 진행 상황
+
+### 2026-01-19
+
+- `AdminPatchList.tsx`에서 `patchVersion` 옆에 `patchId` 표시 추가
+
+## 관련 파일
+
+- `src/components/admin/AdminPatchList.tsx`

--- a/docs/work-logs/2026-01-19-패치아이디표시.md
+++ b/docs/work-logs/2026-01-19-패치아이디표시.md
@@ -1,21 +1,25 @@
-# 패치 아이디 표시
+# 패치 아이디 표시 및 검증 스크립트 수정
 
 ## 개요
 
 - **시작일**: 2026-01-19
-- **상태**: 완료
+- **상태**: 진행중
 - **관련 브랜치**: feature/42 (예정)
 
 ## 목표
 
 - [x] 관리자 페이지 패치 목록에서 패치노트 ID도 함께 표시
+- [ ] verify-all-patches.ts 미발견 문제 수정
 
 ## 진행 상황
 
 ### 2026-01-19
 
 - `AdminPatchList.tsx`에서 `patchVersion` 옆에 `patchId` 표시 추가
+- 미발견 원인 분석: 웹페이지가 영문으로 로드되어 한글 캐릭터명 매칭 실패
+- 해결: URL에 `?hl=ko-KR` 파라미터 추가
 
 ## 관련 파일
 
 - `src/components/admin/AdminPatchList.tsx`
+- `scripts/verify-all-patches.ts`

--- a/scripts/debug-parse-patch.ts
+++ b/scripts/debug-parse-patch.ts
@@ -1,0 +1,295 @@
+/**
+ * 디버깅용 패치 파싱 테스트 스크립트
+ * DB 없이 특정 캐릭터/패치ID로 파싱 결과 확인
+ *
+ * 사용법: npx tsx scripts/debug-parse-patch.ts
+ */
+
+import puppeteer, { Browser, Page } from 'puppeteer';
+
+// 테스트 대상
+const TEST_CHARACTER = '다니엘';
+const TEST_PATCH_IDS = [1727];
+
+interface ParsedChange {
+  target: string;
+  stat?: string;
+  before?: string;
+  after?: string;
+  description?: string;
+}
+
+async function parseCharacterFromPatch(
+  page: Page,
+  patchId: number,
+  characterName: string
+): Promise<{ changes: ParsedChange[]; found: boolean; sectionFound: boolean; debug: string[] }> {
+  const url = `https://playeternalreturn.com/posts/news/${patchId}?hl=ko-KR`;
+
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`패치 ${patchId} - ${characterName} 파싱 시작`);
+  console.log(`URL: ${url}`);
+  console.log('='.repeat(60));
+
+  try {
+    await page.goto(url, { waitUntil: 'networkidle2', timeout: 30000 });
+    await new Promise((r) => setTimeout(r, 1000));
+
+    const result = await page.evaluate((charName: string) => {
+      const debug: string[] = [];
+      const content = document.querySelector('.er-article-detail__content');
+
+      if (!content) {
+        debug.push('❌ .er-article-detail__content 요소를 찾을 수 없음');
+        return { changes: [] as ParsedChange[], found: false, sectionFound: false, debug };
+      }
+      debug.push('✅ .er-article-detail__content 찾음');
+
+      // h5 요소들 수집
+      const h5Elements = content.querySelectorAll('h5');
+      debug.push(`📋 h5 요소 개수: ${h5Elements.length}`);
+
+      h5Elements.forEach((h5, i) => {
+        debug.push(`   h5[${i}]: "${h5.textContent?.trim()}"`);
+      });
+
+      // "실험체" 포함된 모든 h5 섹션 찾기
+      const characterSections: Array<{ start: Element; end: Element | null; title: string }> = [];
+      for (let i = 0; i < h5Elements.length; i++) {
+        const text = h5Elements[i].textContent?.trim() || '';
+        if (text.includes('실험체') || text.includes('Character')) {
+          characterSections.push({
+            start: h5Elements[i],
+            end: i + 1 < h5Elements.length ? h5Elements[i + 1] : null,
+            title: text,
+          });
+        }
+      }
+
+      if (characterSections.length === 0) {
+        debug.push('❌ 실험체/Character 섹션을 찾을 수 없음');
+        return { changes: [] as ParsedChange[], found: false, sectionFound: false, debug };
+      }
+
+      debug.push(`\n📌 총 ${characterSections.length}개의 실험체 섹션 발견:`);
+      characterSections.forEach((s, i) => {
+        debug.push(`   [${i}] "${s.title}"`);
+      });
+
+      const allElements = Array.from(content.children);
+      const numericPattern = /^(.+?)\s+([^\s→]+(?:\([^)]*\))?(?:[^→]*?))\s*→\s*(.+)$/;
+
+      // 각 실험체 섹션을 순회하며 캐릭터 찾기
+      for (let secIdx = 0; secIdx < characterSections.length; secIdx++) {
+        const section = characterSections[secIdx];
+        debug.push(`\n${'─'.repeat(50)}`);
+        debug.push(`🔍 섹션 [${secIdx}] 검사: "${section.title}"`);
+
+        // 이 섹션의 요소만 수집
+        const sectionElements: Element[] = [];
+        let inSection = false;
+
+        for (const el of allElements) {
+          if (el === section.start) {
+            inSection = true;
+            continue;
+          }
+          if (section.end && el === section.end) {
+            break;
+          }
+          if (inSection) {
+            sectionElements.push(el);
+          }
+        }
+
+        debug.push(`   섹션 내 요소 개수: ${sectionElements.length}`);
+
+        // 이 섹션에서 발견된 캐릭터 이름들
+        const foundCharactersInSection: string[] = [];
+        for (const el of sectionElements) {
+          if (el.tagName === 'P') {
+            const strong = el.querySelector('span > strong');
+            if (strong) {
+              const strongText = strong.textContent?.trim() || '';
+              const span = el.querySelector('span');
+              const spanText = span?.textContent?.trim() || '';
+
+              // 조건1: span 전체가 strong과 같음 (기존)
+              // 조건2: strong 뒤가 <br> 또는 끝
+              const nextSibling = strong.nextSibling;
+              const isFollowedByBrOrEnd =
+                !nextSibling ||
+                (nextSibling.nodeType === 1 && (nextSibling as Element).tagName === 'BR') ||
+                (nextSibling.nodeType === 3 && nextSibling.textContent?.trim() === '');
+
+              const isCharacterName =
+                /^[가-힣&\s]+$/.test(strongText) &&
+                (spanText === strongText || isFollowedByBrOrEnd);
+
+              if (isCharacterName) {
+                foundCharactersInSection.push(strongText);
+                debug.push(
+                  `      캐릭터 발견: "${strongText}" (span===strong: ${spanText === strongText}, br뒤: ${isFollowedByBrOrEnd})`
+                );
+              }
+            }
+          }
+        }
+
+        debug.push(`   발견된 캐릭터: [${foundCharactersInSection.join(', ')}]`);
+
+        // 찾는 캐릭터가 이 섹션에 있는지 확인
+        if (!foundCharactersInSection.includes(charName)) {
+          debug.push(`   → "${charName}" 없음, 다음 섹션으로...`);
+          continue;
+        }
+
+        debug.push(`   ✅ "${charName}" 발견! 변경사항 파싱 시작`);
+
+        // 캐릭터 변경사항 파싱
+        const charChanges: ParsedChange[] = [];
+        let currentTarget = '기본 스탯';
+        let isCollecting = false;
+
+        for (const el of sectionElements) {
+          if (el.tagName === 'P') {
+            const strong = el.querySelector('span > strong');
+            if (strong) {
+              const strongText = strong.textContent?.trim() || '';
+              const span = el.querySelector('span');
+              const spanText = span?.textContent?.trim() || '';
+
+              // 조건1: span 전체가 strong과 같음 (기존)
+              // 조건2: strong 뒤가 <br> 또는 끝
+              const nextSibling = strong.nextSibling;
+              const isFollowedByBrOrEnd =
+                !nextSibling ||
+                (nextSibling.nodeType === 1 && (nextSibling as Element).tagName === 'BR') ||
+                (nextSibling.nodeType === 3 && nextSibling.textContent?.trim() === '');
+
+              const isCharacterName =
+                /^[가-힣&\s]+$/.test(strongText) &&
+                (spanText === strongText || isFollowedByBrOrEnd);
+
+              if (isCharacterName) {
+                if (isCollecting) {
+                  // 다른 캐릭터 시작 → 수집 종료
+                  debug.push(`   수집 종료 (다음 캐릭터: ${strongText})`);
+                  break;
+                }
+                if (strongText === charName) {
+                  isCollecting = true;
+                  currentTarget = '기본 스탯';
+                  debug.push(`   수집 시작: ${charName}`);
+                }
+              }
+            }
+          }
+
+          if (el.tagName === 'UL' && isCollecting) {
+            const topLevelLis = el.querySelectorAll(':scope > li');
+
+            for (const topLi of Array.from(topLevelLis)) {
+              const firstP = topLi.querySelector(':scope > p');
+              let headerText = '';
+              if (firstP) {
+                const span = firstP.querySelector('span');
+                if (span) {
+                  headerText = span.textContent?.replace(/\s+/g, ' ').trim() || '';
+                }
+              }
+
+              const skillMatch = headerText.match(
+                /^([^→]+\((?:[가-힣A-Za-z\s-]*)?[QWERP패시브]\d?\)(?:\s*-\s*[^→]+\([QWERP]\d?\))?)/
+              );
+
+              if (skillMatch && !headerText.includes('→')) {
+                currentTarget = skillMatch[0].trim();
+              }
+
+              const descendantLis = topLi.querySelectorAll('li');
+              for (const descLi of Array.from(descendantLis)) {
+                const descP = descLi.querySelector(':scope > p');
+                let descSpan: Element | null = null;
+
+                if (descP) {
+                  descSpan = descP.querySelector('span');
+                } else {
+                  descSpan = descLi.querySelector(':scope > span');
+                }
+
+                if (descSpan) {
+                  const descText = descSpan.textContent?.replace(/\s+/g, ' ').trim() || '';
+                  if (!descText || descText.length < 3) continue;
+
+                  if (descText.includes('→')) {
+                    const match = descText.match(numericPattern);
+                    if (match) {
+                      charChanges.push({
+                        target: currentTarget,
+                        stat: match[1].trim(),
+                        before: match[2].trim(),
+                        after: match[3].trim(),
+                      });
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        debug.push(`   📊 파싱된 변경사항: ${charChanges.length}개`);
+        if (charChanges.length > 0) {
+          debug.push(`   샘플:`);
+          charChanges.slice(0, 3).forEach((c) => {
+            debug.push(`     [${c.target}] ${c.stat}: ${c.before} → ${c.after}`);
+          });
+        }
+
+        // 캐릭터를 찾았으면 반환
+        return { changes: charChanges, found: true, sectionFound: true, debug };
+      }
+
+      // 모든 섹션 검사 후에도 못 찾음
+      debug.push(`\n❌ 모든 섹션을 검사했지만 "${charName}"을 찾지 못함`);
+      return { changes: [] as ParsedChange[], found: false, sectionFound: true, debug };
+    }, characterName);
+
+    return result;
+  } catch (error) {
+    console.error(`  파싱 오류:`, error);
+    return { changes: [], found: false, sectionFound: false, debug: [`오류: ${error}`] };
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('디버깅 패치 파싱 테스트');
+  console.log(`캐릭터: ${TEST_CHARACTER}`);
+  console.log(`패치 ID: ${TEST_PATCH_IDS.join(', ')}`);
+
+  const browser: Browser = await puppeteer.launch({ headless: true });
+  const page: Page = await browser.newPage();
+  await page.setCookie({ name: 'locale', value: 'ko_KR', domain: 'playeternalreturn.com' });
+
+  for (const patchId of TEST_PATCH_IDS) {
+    const result = await parseCharacterFromPatch(page, patchId, TEST_CHARACTER);
+
+    console.log('\n--- 디버그 로그 ---');
+    for (const line of result.debug) {
+      console.log(line);
+    }
+
+    console.log('\n--- 최종 결과 ---');
+    console.log(`sectionFound: ${result.sectionFound}`);
+    console.log(`found: ${result.found}`);
+    console.log(`changes: ${result.changes.length}개`);
+
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  await browser.close();
+  console.log('\n\n테스트 완료');
+}
+
+main().catch(console.error);

--- a/src/components/admin/AdminPatchList.tsx
+++ b/src/components/admin/AdminPatchList.tsx
@@ -175,6 +175,7 @@ export function AdminPatchList({
                 {getChangeTypeLabel(patch.overallChange)}
               </span>
               <span className="text-white font-medium">{patch.patchVersion}</span>
+              <span className="text-gray-500 text-xs">(ID: {patch.patchId})</span>
               <span className="text-gray-400 text-sm">{formatDate(patch.patchDate)}</span>
             </div>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## 관련 이슈

closes #42 

## 변경 사항

- 모든 "실험체" 섹션을 순회하여 캐릭터 검색 (신규 실험체 섹션 오인식 문제 해결)
- 캐릭터 이름 인식 조건 완화 (`<strong>` 뒤가 `<br>` 또는 끝인 경우도 인식)
- 디버깅용 스크립트 추가 (`debug-parse-patch.ts`)

 ### 문제 1: 신규 실험체 섹션 오인식
  - 기존: 첫 번째 "실험체" 포함 h5만 검사 → "신규 실험체 - 헨리" 같은 섹션에서 멈춤
  - 수정: 모든 "실험체" 섹션을 순회하며 캐릭터 찾을 때까지 검색

 ### 문제 2: 캐릭터 이름 인식 조건
  - 기존: `spanText === strongText` 조건만 사용
  - 수정: `<strong>` 뒤가 `<br>` 또는 끝인 경우도 캐릭터 이름으로 인식


## 변경 유형

- [x] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
