### PR TITLE
feature/53 [fix] 시즌 경계 패치노트 분류 보정

### DIFF
--- a/docs/work-logs/2026-01-27-시즌분류날짜보정.md
+++ b/docs/work-logs/2026-01-27-시즌분류날짜보정.md
@@ -1,0 +1,61 @@
+# 시즌 분류 날짜 보정
+
+## 작업 정보
+
+- **브랜치**: feature/53
+- **상태**: 완료
+- **날짜**: 2026-01-27
+
+## 문제
+
+패치노트 날짜가 실제 적용일이 아닌 작성일로 저장되어 있어서 시즌 경계에서 잘못 분류되는 문제.
+
+### 예시
+
+- 시즌 10 시작일: 2026-01-22
+- 시즌 10 첫 패치노트 작성일: 2026-01-21 (적용은 다음날)
+- 현재: S9로 잘못 분류됨
+- 기대: S10으로 분류되어야 함
+
+### 왜 날짜를 일괄 수정하지 않는가?
+
+- 핫픽스: 당일 적용 (날짜 = 적용일)
+- 일반 패치: 다음날 적용 (날짜 = 작성일)
+- 혼재되어 있어서 일괄 수정 불가
+
+## 해결 방안
+
+`getSeasonByDate()` 함수에서 시즌 시작일을 1일 앞당겨서 비교
+
+```typescript
+// AS-IS
+if (patchDate >= season.startDate) {
+  return season;
+}
+
+// TO-BE
+const adjustedStartDate = new Date(season.startDate);
+adjustedStartDate.setDate(adjustedStartDate.getDate() - 1);
+const adjustedStartDateStr = adjustedStartDate.toISOString().slice(0, 10);
+
+if (patchDate >= adjustedStartDateStr) {
+  return season;
+}
+```
+
+### 영향 분석
+
+- 시즌 경계 패치노트: 올바른 시즌으로 분류됨
+- 핫픽스: 영향 없음 (시즌 중간에 작성되므로)
+- 시즌 종료일 표시: 영향 없음 (`getSeasonEndDate()`는 별도 함수)
+
+## 수정 파일
+
+- `src/lib/seasons.ts` - `getSeasonByDate()` 함수 수정
+
+## 진행 상황
+
+- [x] 문제 분석
+- [x] 해결 방안 설계
+- [x] 코드 수정
+- [x] 빌드 테스트 통과

--- a/src/lib/seasons.ts
+++ b/src/lib/seasons.ts
@@ -146,12 +146,22 @@ export function getSeasonByPatchVersion(patchVersion: string): Season | null {
 /**
  * 패치 날짜로 시즌 찾기
  * @param patchDate YYYY-MM-DD 형식의 날짜 문자열
+ *
+ * 패치노트 날짜는 작성일 기준이고 실제 적용은 다음날이므로,
+ * 시즌 시작 전날의 패치노트도 해당 시즌으로 분류한다.
+ * (핫픽스는 당일 적용이라 영향 없음)
  */
 export function getSeasonByDate(patchDate: string): Season | null {
   // 최신 시즌부터 역순으로 확인
   for (let i = SEASONS.length - 1; i >= 0; i--) {
     const season = SEASONS[i];
-    if (patchDate >= season.startDate) {
+
+    // 시즌 시작 전날부터 해당 시즌으로 분류
+    const adjustedStartDate = new Date(season.startDate);
+    adjustedStartDate.setDate(adjustedStartDate.getDate() - 1);
+    const adjustedStartDateStr = adjustedStartDate.toISOString().slice(0, 10);
+
+    if (patchDate >= adjustedStartDateStr) {
       return season;
     }
   }


### PR DESCRIPTION


## 관련 이슈

closes #53 

## 변경 사항

- 패치노트 날짜가 작성일 기준이라 시즌 변경 패치가
- 이전 시즌으로 잘못 분류되는 문제 수정.
- 시즌 시작 전날의 패치노트도 해당 시즌으로 분류하도록 변경.

## 변경 유형

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
