### PR TITLE
[feat] 실험체 스텟 비교 페이지 추가

### DIFF
--- a/docs/work-logs/2026-04-20-실험체스텟비교페이지.md
+++ b/docs/work-logs/2026-04-20-실험체스텟비교페이지.md
@@ -1,0 +1,44 @@
+# 실험체 스텟 비교 페이지
+
+## 개요
+
+- **시작일**: 2026-04-20
+- **상태**: 완료
+- **관련 브랜치**: feature/93
+
+## 목표
+
+- [x] `/stats` 경로 생성 및 헤더 네비 추가
+- [x] 실험체별 상세 스텟 조회 UI (`/stats/[name]`)
+- [x] 카테고리별 스텟 랭킹 UI (`/stats?stat=hp` 등)
+
+## 진행 상황
+
+### 2026-04-20
+
+- `src/app/stats/page.tsx` 경로 생성 (빈 페이지)
+- `NavLinks.tsx`에 '스텟 비교' 항목 추가
+
+### 2026-04-20 (2차)
+
+- `src/lib/stats-data.ts` 작성 - `loadAllStats`, `STAT_CATEGORIES`, `getRankings`, `findStatConfig`
+- `src/app/stats/page.tsx` - 카테고리 탭(searchParams) + 랭킹 리스트 구현
+- `src/app/stats/[name]/page.tsx` - 실험체 상세 스텟 카드 + 순위 배지 + 무기군 테이블
+- `src/app/stats/[name]/not-found.tsx` 추가
+- 빌드 확인: `/stats/[name]` 87개 SSG 생성 완료
+
+## 실행 스크립트
+
+해당 없음 (프론트엔드 페이지 작업)
+
+## 중단 시 이어서 할 작업
+
+- [ ] Firebase `characters/{name}.baseStats` 데이터 읽어오는 lib 함수 작성
+- [ ] 스텟 비교 페이지 UI 구현 (카테고리 탭 + 랭킹 리스트 + 실험체 상세)
+
+## 관련 파일
+
+- `src/app/stats/page.tsx` (신규)
+- `src/components/NavLinks.tsx`
+- `src/types/patch.ts` - `BaseStats`, `WeaponStat` 타입 (기존)
+- `scripts/upload-character-stats.ts` - Firebase 업로드 기준 구조 참고

--- a/src/app/stats/[name]/not-found.tsx
+++ b/src/app/stats/[name]/not-found.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function StatsDetailNotFound(): React.ReactElement {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#0a0b0f]">
+      <div className="px-4 text-center">
+        <h1 className="mb-4 text-8xl font-bold text-indigo-500">404</h1>
+        <h2 className="mb-2 text-2xl font-semibold text-zinc-200">실험체를 찾을 수 없습니다</h2>
+        <p className="mb-8 text-zinc-400">스텟 데이터가 없거나 존재하지 않는 실험체입니다.</p>
+        <Link
+          href="/stats"
+          className="rounded-lg bg-indigo-600 px-6 py-3 font-medium text-white transition-colors hover:bg-indigo-500"
+        >
+          스텟 랭킹으로 돌아가기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/stats/[name]/page.tsx
+++ b/src/app/stats/[name]/page.tsx
@@ -1,0 +1,351 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import {
+  loadAllStats,
+  STAT_CATEGORIES,
+  getRankings,
+  getWeaponStatRanking,
+  getCharacterWeaponRank,
+  getRankForWeaponCombo,
+} from '@/lib/stats-data';
+import { loadImageMap } from '@/lib/patch-data';
+import CharacterImage from '@/components/CharacterImage';
+
+type Props = {
+  params: Promise<{ name: string }>;
+};
+
+export async function generateStaticParams(): Promise<Array<{ name: string }>> {
+  const allStats = await loadAllStats();
+  return allStats.map((c) => ({ name: encodeURIComponent(c.name) }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { name } = await params;
+  const decodedName = decodeURIComponent(name);
+  return {
+    title: `${decodedName} 스텟`,
+    description: `이터널 리턴 ${decodedName}의 기본 스텟과 전체 순위를 확인하세요.`,
+  };
+}
+
+type StatCardData = {
+  key: string;
+  label: string;
+  description: string;
+  statKey: string;
+  value: number;
+  growth: number | null;
+  rankInfo: { rank: number; total: number } | undefined;
+  minVal: number;
+  maxVal: number;
+  barClass: string;
+  textClass: string;
+  bgClass: string;
+  formatValue: (v: number) => string;
+};
+
+export default async function StatsDetailPage({ params }: Props): Promise<React.JSX.Element> {
+  const { name } = await params;
+  const decodedName = decodeURIComponent(name);
+
+  const [allStats, imageMap] = await Promise.all([loadAllStats(), loadImageMap()]);
+  const character = allStats.find((c) => c.name === decodedName);
+
+  if (!character) notFound();
+
+  const weaponRankings = {
+    attackSpeedGrowth: getWeaponStatRanking(allStats, 'attackSpeedGrowth'),
+    basicAttackAmpGrowth: getWeaponStatRanking(allStats, 'basicAttackAmpGrowth'),
+    skillAmpGrowth: getWeaponStatRanking(allStats, 'skillAmpGrowth'),
+  };
+
+  const statCardData: StatCardData[] = STAT_CATEGORIES.flatMap((config) => {
+    const value = config.getValue(character.baseStats);
+    if (value === null) return [];
+
+    const validValues = allStats
+      .filter((e) => config.getValue(e.baseStats) !== null)
+      .map((e) => config.getValue(e.baseStats) as number)
+      .sort((a, b) => a - b);
+
+    let rankInfo: { rank: number; total: number } | undefined;
+    if (config.weaponStatKey) {
+      const weaponRanking = getWeaponStatRanking(allStats, config.weaponStatKey);
+      rankInfo = getCharacterWeaponRank(weaponRanking, character.name);
+    } else {
+      rankInfo = getRankings(allStats, config).get(character.name);
+    }
+
+    return [
+      {
+        key: config.key,
+        label: config.label,
+        description: config.description,
+        statKey: config.key,
+        value,
+        growth: config.getGrowth(character.baseStats),
+        rankInfo,
+        minVal: validValues[0] ?? 0,
+        maxVal: validValues[validValues.length - 1] ?? 1,
+        barClass: config.barClass,
+        textClass: config.textClass,
+        bgClass: config.bgClass,
+        formatValue: config.formatValue,
+      },
+    ];
+  });
+
+  const baseCards = statCardData.filter(
+    (d) => STAT_CATEGORIES.find((c) => c.key === d.key)?.section === 'base'
+  );
+  const lv20Cards = statCardData.filter(
+    (d) => STAT_CATEGORIES.find((c) => c.key === d.key)?.section === 'lv20'
+  );
+  const weaponCards = statCardData.filter(
+    (d) => STAT_CATEGORIES.find((c) => c.key === d.key)?.section === 'weapon'
+  );
+
+  const renderStatCard = (d: StatCardData): React.JSX.Element => {
+    const range = d.maxVal === d.minVal ? 1 : d.maxVal - d.minVal;
+    const pct = Math.round(((d.value - d.minVal) / range) * 100);
+
+    return (
+      <div key={d.key} className={`rounded-xl border border-[#2a2d35] p-4 ${d.bgClass}`}>
+        {/* 라벨 + 랭크 */}
+        <div className="mb-3 flex items-start justify-between gap-2">
+          <span className="text-sm font-semibold text-zinc-300">{d.label}</span>
+          {d.rankInfo && (
+            <Link
+              href={`/stats?stat=${d.statKey}`}
+              className={`shrink-0 rounded-md bg-black/30 px-2 py-0.5 text-xs font-bold ${d.textClass} transition-opacity hover:opacity-70`}
+            >
+              {d.rankInfo.rank}위 / {d.rankInfo.total}
+            </Link>
+          )}
+        </div>
+
+        {/* 값 */}
+        <p className={`font-mono text-3xl font-black ${d.textClass}`}>{d.formatValue(d.value)}</p>
+
+        {/* 성장치 */}
+        {d.growth !== null && (
+          <p className="mt-1 text-xs text-zinc-500">
+            레벨당 <span className="font-mono text-zinc-400">+{d.growth}</span>
+          </p>
+        )}
+
+        {/* 바 (전체 분포 내 위치) */}
+        <div className="mt-3 h-1 overflow-hidden rounded-full bg-black/30">
+          <div
+            className={`h-full rounded-full bg-linear-to-r ${d.barClass}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <div className="mt-1 flex justify-between text-xs text-zinc-600">
+          <span>{d.formatValue(d.minVal)}</span>
+          <span>{d.formatValue(d.maxVal)}</span>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0a0b0f]">
+      <div
+        className="pointer-events-none fixed inset-0 bg-[radial-gradient(ellipse_at_top,rgba(99,102,241,0.07),transparent_50%)]"
+        aria-hidden="true"
+      />
+
+      <main className="relative mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+        {/* 뒤로가기 */}
+        <nav aria-label="뒤로가기" className="mb-8">
+          <Link
+            href="/stats"
+            className="group inline-flex items-center gap-2 text-sm text-zinc-500 transition-colors hover:text-indigo-400"
+          >
+            <svg
+              className="h-4 w-4 transition-transform group-hover:-translate-x-1"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            스텟 랭킹으로 돌아가기
+          </Link>
+        </nav>
+
+        {/* 캐릭터 헤더 */}
+        <header className="mb-10 flex items-center gap-5">
+          <CharacterImage name={character.name} imageUrl={imageMap[character.name]} size="lg" />
+          <div>
+            <h1 className="bg-linear-to-r from-white to-zinc-400 bg-clip-text text-4xl font-black tracking-tight text-transparent sm:text-5xl">
+              {character.name}
+            </h1>
+            <div className="mt-2 flex flex-wrap items-center gap-3">
+              <p className="text-zinc-500">기본 스텟</p>
+              <span className="text-zinc-700">·</span>
+              <Link
+                href={`/character/${encodeURIComponent(character.name)}`}
+                className="text-sm text-zinc-500 transition-colors hover:text-violet-400"
+              >
+                패치 히스토리 보기 →
+              </Link>
+            </div>
+          </div>
+        </header>
+
+        {/* 기본 스텟 (Lv.1) */}
+        {baseCards.length > 0 && (
+          <section aria-labelledby="base-stats-heading" className="mb-10">
+            <h2 id="base-stats-heading" className="mb-4 text-lg font-bold text-zinc-200">
+              기본 스텟
+              <span className="ml-2 text-sm font-normal text-zinc-600">Lv.1</span>
+            </h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {baseCards.map(renderStatCard)}
+            </div>
+          </section>
+        )}
+
+        {/* 레벨 20 최종 스텟 */}
+        {lv20Cards.length > 0 && (
+          <section aria-labelledby="lv20-stats-heading" className="mb-10">
+            <h2 id="lv20-stats-heading" className="mb-4 text-lg font-bold text-zinc-200">
+              최종 스텟
+              <span className="ml-2 text-sm font-normal text-zinc-600">
+                Lv.20 · 기본 + 성장 × 19
+              </span>
+            </h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {lv20Cards.map(renderStatCard)}
+            </div>
+          </section>
+        )}
+
+        {/* 무기 성장치 */}
+        {weaponCards.length > 0 && (
+          <section aria-labelledby="weapon-growth-heading" className="mb-10">
+            <h2 id="weapon-growth-heading" className="mb-4 text-lg font-bold text-zinc-200">
+              무기 성장치
+              <span className="ml-2 text-sm font-normal text-zinc-600">무기군 최댓값 기준</span>
+            </h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {weaponCards.map(renderStatCard)}
+            </div>
+          </section>
+        )}
+
+        {/* 무기군별 상세 */}
+        {character.baseStats.weaponStats.length > 0 && (
+          <section aria-labelledby="weapon-stats-heading">
+            <h2 id="weapon-stats-heading" className="mb-4 text-lg font-bold text-zinc-200">
+              무기군별 상세
+            </h2>
+            <div className="overflow-hidden rounded-xl border border-[#2a2d35] bg-[#13151a]">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-[#2a2d35]">
+                      <th className="px-4 py-3 text-left font-semibold text-zinc-400">무기군</th>
+                      <th className="px-4 py-3 text-right font-semibold text-zinc-400">
+                        공속 성장
+                      </th>
+                      <th className="px-4 py-3 text-right font-semibold text-zinc-400">
+                        기공 증폭
+                      </th>
+                      <th className="px-4 py-3 text-right font-semibold text-zinc-400">
+                        스킬 증폭
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {character.baseStats.weaponStats.map((ws) => {
+                      const atkRank = getRankForWeaponCombo(
+                        weaponRankings.attackSpeedGrowth,
+                        character.name,
+                        ws.weaponType
+                      );
+                      const ampRank = getRankForWeaponCombo(
+                        weaponRankings.basicAttackAmpGrowth,
+                        character.name,
+                        ws.weaponType
+                      );
+                      const skillRank = getRankForWeaponCombo(
+                        weaponRankings.skillAmpGrowth,
+                        character.name,
+                        ws.weaponType
+                      );
+
+                      return (
+                        <tr key={ws.weaponType} className="border-b border-[#1a1d24] last:border-0">
+                          <td className="px-4 py-3 font-medium text-zinc-200">{ws.weaponType}</td>
+                          <td className="px-4 py-3 text-right">
+                            {ws.attackSpeedGrowth !== null ? (
+                              <div className="flex items-center justify-end gap-2">
+                                {atkRank && (
+                                  <span className="text-xs text-zinc-500">
+                                    {atkRank.rank}위/{atkRank.total}
+                                  </span>
+                                )}
+                                <span className="font-mono text-purple-400">
+                                  +{ws.attackSpeedGrowth}%
+                                </span>
+                              </div>
+                            ) : (
+                              <span className="text-zinc-600">-</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            {ws.basicAttackAmpGrowth !== null ? (
+                              <div className="flex items-center justify-end gap-2">
+                                {ampRank && (
+                                  <span className="text-xs text-zinc-500">
+                                    {ampRank.rank}위/{ampRank.total}
+                                  </span>
+                                )}
+                                <span className="font-mono text-cyan-400">
+                                  +{ws.basicAttackAmpGrowth}%
+                                </span>
+                              </div>
+                            ) : (
+                              <span className="text-zinc-600">-</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            {ws.skillAmpGrowth !== null ? (
+                              <div className="flex items-center justify-end gap-2">
+                                {skillRank && (
+                                  <span className="text-xs text-zinc-500">
+                                    {skillRank.rank}위/{skillRank.total}
+                                  </span>
+                                )}
+                                <span className="font-mono text-orange-400">
+                                  +{ws.skillAmpGrowth}%
+                                </span>
+                              </div>
+                            ) : (
+                              <span className="text-zinc-600">-</span>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,0 +1,185 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  loadAllStats,
+  STAT_CATEGORIES,
+  STAT_SECTIONS,
+  findStatConfig,
+  getWeaponStatRanking,
+} from '@/lib/stats-data';
+import { loadImageMap } from '@/lib/patch-data';
+import CharacterImage from '@/components/CharacterImage';
+
+export const metadata: Metadata = {
+  title: '스텟 랭킹',
+  description: '이터널 리턴 실험체별 기본 스텟을 비교하고 카테고리별 랭킹을 확인하세요.',
+};
+
+type Props = {
+  searchParams: Promise<{ stat?: string }>;
+};
+
+type RankedItem = {
+  characterName: string;
+  weaponType: string | null;
+  value: number;
+  growth: number | null;
+};
+
+export default async function StatsPage({ searchParams }: Props): Promise<React.JSX.Element> {
+  const { stat } = await searchParams;
+  const config = findStatConfig(stat);
+
+  const [allStats, imageMap] = await Promise.all([loadAllStats(), loadImageMap()]);
+
+  const isWeaponStat = config.weaponStatKey !== undefined;
+
+  const rankedItems: RankedItem[] = isWeaponStat
+    ? getWeaponStatRanking(allStats, config.weaponStatKey!).map((e) => ({
+        characterName: e.characterName,
+        weaponType: e.weaponType,
+        value: e.value,
+        growth: null,
+      }))
+    : allStats
+        .filter((c) => config.getValue(c.baseStats) !== null)
+        .sort((a, b) => (config.getValue(b.baseStats) ?? 0) - (config.getValue(a.baseStats) ?? 0))
+        .map((c) => ({
+          characterName: c.name,
+          weaponType: null,
+          value: config.getValue(c.baseStats) ?? 0,
+          growth: config.getGrowth(c.baseStats),
+        }));
+
+  const maxValue = rankedItems.length > 0 ? rankedItems[0].value : 1;
+
+  return (
+    <div className="min-h-screen bg-[#0a0b0f]">
+      <div
+        className="pointer-events-none fixed inset-0 bg-[radial-gradient(ellipse_at_top,rgba(99,102,241,0.07),transparent_50%)]"
+        aria-hidden="true"
+      />
+
+      <main className="relative mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+        {/* 헤더 */}
+        <header className="mb-8">
+          <h1 className="bg-linear-to-r from-indigo-300 via-violet-300 to-indigo-200 bg-clip-text text-4xl font-black tracking-tight text-transparent sm:text-5xl">
+            스텟 랭킹
+          </h1>
+          <p className="mt-2 text-zinc-400">
+            {isWeaponStat ? (
+              <>
+                캐릭터 × 무기군 조합 순위 ·{' '}
+                <span className="font-mono text-indigo-400">{rankedItems.length}</span>개 집계
+              </>
+            ) : (
+              <>
+                실험체 기본 스텟 순위 ·{' '}
+                <span className="font-mono text-indigo-400">{rankedItems.length}</span>명 집계
+              </>
+            )}
+          </p>
+        </header>
+
+        {/* 카테고리 탭 - 섹션별 */}
+        <nav className="mb-6 space-y-2" aria-label="스텟 카테고리">
+          {STAT_SECTIONS.map(({ key: section, label: sectionLabel }) => {
+            const cats = STAT_CATEGORIES.filter((c) => c.section === section);
+            return (
+              <div key={section} className="flex flex-wrap items-center gap-2">
+                <span className="w-16 shrink-0 text-right text-xs text-zinc-600">
+                  {sectionLabel}
+                </span>
+                {cats.map((cat) => {
+                  const isActive = cat.key === config.key;
+                  return (
+                    <Link
+                      key={cat.key}
+                      href={`/stats?stat=${cat.key}`}
+                      className={`rounded-lg px-3 py-1.5 text-sm font-semibold transition-colors ${
+                        isActive
+                          ? `${cat.bgClass} ${cat.textClass}`
+                          : 'bg-[#13151a] text-zinc-400 hover:bg-[#1a1d24] hover:text-zinc-200'
+                      }`}
+                    >
+                      {cat.label}
+                    </Link>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </nav>
+
+        <p className="mb-5 text-sm text-zinc-500">{config.description}</p>
+
+        {/* 랭킹 리스트 */}
+        <div className="space-y-2">
+          {rankedItems.map((item, index) => {
+            const pct = Math.round((item.value / maxValue) * 100);
+
+            return (
+              <Link
+                key={`${item.characterName}-${item.weaponType ?? ''}-${index}`}
+                href={`/stats/${encodeURIComponent(item.characterName)}`}
+                className="group flex items-center gap-4 rounded-xl border border-[#2a2d35] bg-[#13151a] px-4 py-3 transition-all duration-200 hover:border-indigo-500/30 hover:shadow-[0_0_20px_rgba(99,102,241,0.1)]"
+              >
+                {/* 순위 */}
+                <div
+                  className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sm font-black ${
+                    index === 0
+                      ? 'bg-yellow-400/20 text-yellow-300'
+                      : index === 1
+                        ? 'bg-zinc-400/10 text-zinc-300'
+                        : index === 2
+                          ? 'bg-orange-700/20 text-orange-400'
+                          : 'bg-[#1a1d24] text-zinc-500'
+                  }`}
+                >
+                  {index + 1}
+                </div>
+
+                {/* 이미지 */}
+                <CharacterImage
+                  name={item.characterName}
+                  imageUrl={imageMap[item.characterName]}
+                  size="sm"
+                />
+
+                {/* 이름 + 무기군 배지 + 바 */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="truncate font-semibold text-zinc-100 transition-colors group-hover:text-indigo-300">
+                        {item.characterName}
+                      </span>
+                      {item.weaponType && (
+                        <span className="shrink-0 rounded-md bg-[#1a1d24] px-2 py-0.5 text-xs text-zinc-400">
+                          {item.weaponType}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex shrink-0 items-center gap-3 text-sm">
+                      {item.growth !== null && (
+                        <span className="text-zinc-500">+{item.growth}</span>
+                      )}
+                      <span className={`font-mono font-bold ${config.textClass}`}>
+                        {config.formatValue(item.value)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="mt-2 h-1 overflow-hidden rounded-full bg-[#1a1d24]">
+                    <div
+                      className={`h-full rounded-full bg-linear-to-r ${config.barClass} transition-all`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 const NAV_ITEMS = [
   { href: '/', label: '패치 내역' },
   { href: '/bugs', label: '버그 랭킹' },
+  { href: '/stats', label: '스텟 비교' },
 ] as const;
 
 export default function NavLinks(): React.JSX.Element {

--- a/src/lib/stats-data.ts
+++ b/src/lib/stats-data.ts
@@ -1,0 +1,288 @@
+import { unstable_cache } from 'next/cache';
+import { db } from './firebase-admin';
+import type { BaseStats, WeaponStat } from '@/types/patch';
+
+export type CharacterStatEntry = {
+  name: string;
+  baseStats: BaseStats;
+};
+
+export type StatKey =
+  | 'hp'
+  | 'attack'
+  | 'defense'
+  | 'moveSpeed'
+  | 'attackSpeed'
+  | 'hp20'
+  | 'attack20'
+  | 'defense20'
+  | 'attackSpeedGrowth'
+  | 'basicAttackAmpGrowth'
+  | 'skillAmpGrowth';
+
+export type WeaponStatKey = 'attackSpeedGrowth' | 'basicAttackAmpGrowth' | 'skillAmpGrowth';
+
+export type WeaponStatEntry = {
+  characterName: string;
+  weaponType: string;
+  value: number;
+};
+
+export type StatSection = 'base' | 'lv20' | 'weapon';
+
+export type StatConfig = {
+  key: StatKey;
+  label: string;
+  description: string;
+  section: StatSection;
+  barClass: string;
+  textClass: string;
+  bgClass: string;
+  getValue: (stats: BaseStats) => number | null;
+  getGrowth: (stats: BaseStats) => number | null;
+  formatValue: (v: number) => string;
+  weaponStatKey?: WeaponStatKey;
+};
+
+const defaultFormat = (v: number): string => String(v);
+const decimalFormat = (v: number): string => v.toFixed(2);
+const percentFormat = (v: number): string => `${v}%`;
+const roundedFormat = (v: number): string => Math.round(v).toLocaleString('ko-KR');
+
+const lv20 = (base: number | null, growth: number | null): number | null =>
+  base !== null && growth !== null ? base + growth * 19 : null;
+
+const getMaxWeaponStat = (
+  weaponStats: WeaponStat[],
+  key: keyof Pick<WeaponStat, 'attackSpeedGrowth' | 'basicAttackAmpGrowth' | 'skillAmpGrowth'>
+): number | null => {
+  const values = weaponStats.map((ws) => ws[key]).filter((v): v is number => v !== null);
+  return values.length > 0 ? Math.max(...values) : null;
+};
+
+export const STAT_CATEGORIES: StatConfig[] = [
+  // ── 기본 스텟 (Lv.1) ─────────────────────────
+  {
+    key: 'hp',
+    label: '체력',
+    description: '레벨 1 기본 체력',
+    section: 'base',
+    barClass: 'from-emerald-500 to-emerald-400',
+    textClass: 'text-emerald-400',
+    bgClass: 'bg-emerald-500/10',
+    getValue: (s) => s.hpBase,
+    getGrowth: (s) => s.hpGrowth,
+    formatValue: defaultFormat,
+  },
+  {
+    key: 'attack',
+    label: '공격력',
+    description: '레벨 1 기본 공격력',
+    section: 'base',
+    barClass: 'from-rose-500 to-rose-400',
+    textClass: 'text-rose-400',
+    bgClass: 'bg-rose-500/10',
+    getValue: (s) => s.attackBase,
+    getGrowth: (s) => s.attackGrowth,
+    formatValue: defaultFormat,
+  },
+  {
+    key: 'defense',
+    label: '방어력',
+    description: '레벨 1 기본 방어력',
+    section: 'base',
+    barClass: 'from-sky-500 to-sky-400',
+    textClass: 'text-sky-400',
+    bgClass: 'bg-sky-500/10',
+    getValue: (s) => s.defenseBase,
+    getGrowth: (s) => s.defenseGrowth,
+    formatValue: defaultFormat,
+  },
+  {
+    key: 'moveSpeed',
+    label: '이동속도',
+    description: '기본 이동속도',
+    section: 'base',
+    barClass: 'from-amber-500 to-amber-400',
+    textClass: 'text-amber-400',
+    bgClass: 'bg-amber-500/10',
+    getValue: (s) => s.moveSpeed,
+    getGrowth: () => null,
+    formatValue: defaultFormat,
+  },
+  {
+    key: 'attackSpeed',
+    label: '공격속도',
+    description: '레벨 1 기본 공격속도',
+    section: 'base',
+    barClass: 'from-violet-500 to-violet-400',
+    textClass: 'text-violet-400',
+    bgClass: 'bg-violet-500/10',
+    getValue: (s) => s.attackSpeedBase,
+    getGrowth: () => null,
+    formatValue: decimalFormat,
+  },
+  // ── 레벨 20 최종 스텟 ─────────────────────────
+  {
+    key: 'hp20',
+    label: '체력 (Lv.20)',
+    description: '레벨 20 최대 체력 · 기본 + 성장 × 19',
+    section: 'lv20',
+    barClass: 'from-teal-500 to-teal-400',
+    textClass: 'text-teal-400',
+    bgClass: 'bg-teal-500/10',
+    getValue: (s) => lv20(s.hpBase, s.hpGrowth),
+    getGrowth: () => null,
+    formatValue: roundedFormat,
+  },
+  {
+    key: 'attack20',
+    label: '공격력 (Lv.20)',
+    description: '레벨 20 최대 공격력 · 기본 + 성장 × 19',
+    section: 'lv20',
+    barClass: 'from-pink-500 to-pink-400',
+    textClass: 'text-pink-400',
+    bgClass: 'bg-pink-500/10',
+    getValue: (s) => lv20(s.attackBase, s.attackGrowth),
+    getGrowth: () => null,
+    formatValue: roundedFormat,
+  },
+  {
+    key: 'defense20',
+    label: '방어력 (Lv.20)',
+    description: '레벨 20 최대 방어력 · 기본 + 성장 × 19',
+    section: 'lv20',
+    barClass: 'from-blue-500 to-blue-400',
+    textClass: 'text-blue-400',
+    bgClass: 'bg-blue-500/10',
+    getValue: (s) => lv20(s.defenseBase, s.defenseGrowth),
+    getGrowth: () => null,
+    formatValue: roundedFormat,
+  },
+  // ── 무기 성장치 (캐릭터 × 무기군 조합 랭킹) ──
+  {
+    key: 'attackSpeedGrowth',
+    label: '공속 성장',
+    description: '캐릭터 × 무기군 조합 공격속도 성장치 순위',
+    section: 'weapon',
+    barClass: 'from-purple-500 to-purple-400',
+    textClass: 'text-purple-400',
+    bgClass: 'bg-purple-500/10',
+    getValue: (s) => getMaxWeaponStat(s.weaponStats, 'attackSpeedGrowth'),
+    getGrowth: () => null,
+    formatValue: percentFormat,
+    weaponStatKey: 'attackSpeedGrowth',
+  },
+  {
+    key: 'basicAttackAmpGrowth',
+    label: '기공 증폭',
+    description: '캐릭터 × 무기군 조합 기본공격 증폭 성장치 순위',
+    section: 'weapon',
+    barClass: 'from-cyan-500 to-cyan-400',
+    textClass: 'text-cyan-400',
+    bgClass: 'bg-cyan-500/10',
+    getValue: (s) => getMaxWeaponStat(s.weaponStats, 'basicAttackAmpGrowth'),
+    getGrowth: () => null,
+    formatValue: percentFormat,
+    weaponStatKey: 'basicAttackAmpGrowth',
+  },
+  {
+    key: 'skillAmpGrowth',
+    label: '스킬 증폭',
+    description: '캐릭터 × 무기군 조합 스킬 증폭 성장치 순위',
+    section: 'weapon',
+    barClass: 'from-orange-500 to-orange-400',
+    textClass: 'text-orange-400',
+    bgClass: 'bg-orange-500/10',
+    getValue: (s) => getMaxWeaponStat(s.weaponStats, 'skillAmpGrowth'),
+    getGrowth: () => null,
+    formatValue: percentFormat,
+    weaponStatKey: 'skillAmpGrowth',
+  },
+];
+
+export const STAT_SECTIONS: { key: StatSection; label: string }[] = [
+  { key: 'base', label: '기본' },
+  { key: 'lv20', label: 'Lv.20' },
+  { key: 'weapon', label: '무기 성장' },
+];
+
+// 캐릭터 × 무기군 조합 랭킹 (내림차순)
+export const getWeaponStatRanking = (
+  entries: CharacterStatEntry[],
+  key: WeaponStatKey
+): WeaponStatEntry[] => {
+  const result: WeaponStatEntry[] = [];
+  for (const entry of entries) {
+    for (const ws of entry.baseStats.weaponStats) {
+      const value = ws[key];
+      if (value !== null) {
+        result.push({ characterName: entry.name, weaponType: ws.weaponType, value });
+      }
+    }
+  }
+  return result.sort((a, b) => b.value - a.value);
+};
+
+// 캐릭터의 최고 순위 (무기군 중 가장 높은 값 기준)
+export const getCharacterWeaponRank = (
+  weaponRanking: WeaponStatEntry[],
+  characterName: string
+): { rank: number; total: number } | undefined => {
+  const idx = weaponRanking.findIndex((e) => e.characterName === characterName);
+  if (idx === -1) return undefined;
+  return { rank: idx + 1, total: weaponRanking.length };
+};
+
+// 특정 캐릭터 × 무기군 조합의 순위
+export const getRankForWeaponCombo = (
+  weaponRanking: WeaponStatEntry[],
+  characterName: string,
+  weaponType: string
+): { rank: number; total: number } | null => {
+  const idx = weaponRanking.findIndex(
+    (e) => e.characterName === characterName && e.weaponType === weaponType
+  );
+  if (idx === -1) return null;
+  return { rank: idx + 1, total: weaponRanking.length };
+};
+
+export const findStatConfig = (key: string | undefined): StatConfig =>
+  STAT_CATEGORIES.find((c) => c.key === key) ?? STAT_CATEGORIES[0];
+
+export const getRankings = (
+  entries: CharacterStatEntry[],
+  config: StatConfig
+): Map<string, { rank: number; total: number }> => {
+  const valid = entries
+    .filter((e) => config.getValue(e.baseStats) !== null)
+    .sort((a, b) => (config.getValue(b.baseStats) ?? 0) - (config.getValue(a.baseStats) ?? 0));
+
+  const map = new Map<string, { rank: number; total: number }>();
+  valid.forEach((e, i) => {
+    map.set(e.name, { rank: i + 1, total: valid.length });
+  });
+  return map;
+};
+
+const fetchAllStats = async (): Promise<CharacterStatEntry[]> => {
+  const snapshot = await db.collection('characters').get();
+  const results: CharacterStatEntry[] = [];
+
+  snapshot.forEach((doc) => {
+    const data = doc.data();
+    if (data.baseStats) {
+      results.push({
+        name: data.name as string,
+        baseStats: data.baseStats as BaseStats,
+      });
+    }
+  });
+
+  return results.sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+};
+
+export const loadAllStats = unstable_cache(fetchAllStats, ['character-stats'], {
+  revalidate: 3600,
+  tags: ['character-stats'],
+});


### PR DESCRIPTION

## 관련 이슈

closes #93 

## 변경 사항
- /stats: 카테고리별 스텟 랭킹 (기본/Lv.20/무기 성장 섹션 탭)
- /stats/[name]: 실험체 상세 스텟 (기본·최종·무기 성장치 + 순위 배지)
- 무기 성장 랭킹: 캐릭터 × 무기군 조합 기준, 값 없는 조합 제외
- 무기군별 상세 테이블: 공속·기공·스킬 증폭 성장치별 순위 표시
- Lv.20 최종 스텟 계산: 기본 + 성장 × 19
- Header 네비에 '스텟 비교' 링크 추가


## 변경 유형

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
