### PR TITLE
[feat] dak.gg 크롤링으로 체력 재생 스탯 반영 및 UI 표시 추가

### DIFF
--- a/docs/work-logs/2026-04-23-dakgg크로스체크.md
+++ b/docs/work-logs/2026-04-23-dakgg크로스체크.md
@@ -1,0 +1,83 @@
+# dak.gg 크로스체크 - 체력 재생 누락 보정
+
+## 개요
+
+- **시작일**: 2026-04-23
+- **상태**: 완료
+- **관련 브랜치**: feature/97
+
+## 목표
+
+- [ ] dak.gg에서 실험체 기본 스탯 크롤링 (체력 재생 포함)
+- [ ] Firestore의 기존 baseStats와 비교
+- [ ] 누락된 체력 재생(hpRegenBase, hpRegenGrowth) 데이터 확인
+- [ ] 필요 시 다른 스탯 차이도 확인
+- [ ] DB에 체력 재생 데이터 반영
+
+## 배경
+
+나무위키 크롤링 스크립트(`crawl-character-stats.ts`)에서 체력 재생 필드가 누락됨.
+dak.gg는 더 정확하고 최신화된 데이터를 제공하므로 크로스체크 용도로 사용.
+
+### dak.gg URL 패턴
+
+- 캐릭터 목록: `https://dak.gg/er/characters`
+- 소개 페이지: `https://dak.gg/er/characters/{EnglishSlug}/introduction`
+- 무기 타입 지정: `https://dak.gg/er/characters/{EnglishSlug}/introduction?weaponType=Bow`
+
+### 주의사항
+
+- 실험체 슬러그가 영문이며, Firestore의 한글명과 매핑 필요
+- 잘못된 슬러그 입력 시 다른 캐릭터로 리다이렉트됨
+- 무기 타입이 여러 개인 캐릭터는 타입별로 별도 URL 존재
+
+## 진행 상황
+
+### 2026-04-23
+
+- 작업 시작
+- 기존 `crawl-character-stats.ts` 분석 완료 (나무위키 기반)
+- 기존 `CharacterBaseStats` 타입에 hpRegenBase/hpRegenGrowth 없음 확인
+- `character-stats-result.json` 확인 (87개 캐릭터, 체력 재생 누락)
+- `crawl-dakgg-stats.ts` 작성 완료 (체력 재생 포함, 무기 숙련도 포함)
+- `compare-dakgg-stats.ts` 작성 완료 (Firestore vs dak.gg 비교)
+- `upload-dakgg-stats.ts` 작성 + 87개 전체 업로드 완료
+- `src/types/patch.ts` BaseStats에 hpRegenBase/hpRegenGrowth 추가
+- 최종 비교: 87개 전부 일치 ✅
+
+## 실행 스크립트
+
+### 1단계: dak.gg 크롤링
+
+```bash
+npx tsx scripts/crawl-dakgg-stats.ts              # 전체 크롤링
+npx tsx scripts/crawl-dakgg-stats.ts 나딘 가넷    # 특정 캐릭터만
+```
+
+### 2단계: DB와 비교
+
+```bash
+npx tsx scripts/compare-dakgg-stats.ts            # 비교 결과 JSON 출력
+```
+
+### 3단계: 체력 재생 업데이트
+
+```bash
+npx tsx scripts/upload-character-stats.ts         # 기존 업로드 스크립트 활용
+```
+
+## 중단 시 이어서 할 작업
+
+- [ ] `crawl-dakgg-stats.ts` 작성
+- [ ] `compare-dakgg-stats.ts` 작성
+- [ ] 크롤링 실행 후 결과 확인
+- [ ] DB 업데이트 (체력 재생 필드 추가)
+
+## 관련 파일
+
+- `scripts/crawl-dakgg-stats.ts` (신규)
+- `scripts/compare-dakgg-stats.ts` (신규)
+- `scripts/crawl-character-stats.ts` (기존 나무위키)
+- `scripts/upload-character-stats.ts` (DB 업로드)
+- `scripts/character-stats-result.json` (기존 크롤링 결과)
+- `scripts/dakgg-stats-result.json` (신규 결과)

--- a/docs/work-logs/2026-04-23-체력재생스탯표시.md
+++ b/docs/work-logs/2026-04-23-체력재생스탯표시.md
@@ -1,0 +1,41 @@
+# 체력 재생 스탯 비교 표시
+
+## 개요
+
+- **시작일**: 2026-04-23
+- **상태**: 완료
+- **관련 브랜치**: feature/97
+
+## 목표
+
+- [x] `stats-data.ts`에 체력 재생 StatKey 및 STAT_CATEGORIES 추가
+- [x] 스탯 비교 페이지에 체력 재생(Lv.1) 표시
+- [x] 스탯 비교 페이지에 체력 재생(Lv.20) 표시
+- [x] Lv.20 스탯 소수점 표시 수정 (반올림 → 소수점 1자리)
+- [x] Lv.20 스탯 카드에 기본값 + 성장치 표시 추가
+
+## 배경
+
+dak.gg 크롤링으로 `hpRegenBase` / `hpRegenGrowth` 필드를 Firestore에 반영 완료.
+`src/types/patch.ts`의 `BaseStats` 타입에도 이미 추가된 상태.
+이제 스탯 비교 페이지 UI에 체력 재생 항목을 표시해야 함.
+
+## 진행 상황
+
+### 2026-04-23
+
+- 작업 시작
+- `stats-data.ts` 구조 파악 완료
+- `StatKey`에 `'hpRegen'`, `'hpRegen20'` 추가
+- `lv20Format` 함수 추가 (소수점 1자리 또는 정수 한국 표기)
+- `StatComponents` 타입 추가, `StatConfig`에 `getComponents?` 추가
+- `hpRegen` (기본 섹션, green), `hpRegen20` (lv20 섹션, lime) 카테고리 추가
+- `hp20`, `attack20`, `defense20`, `hpRegen20` 모두 `getComponents` 추가
+- `src/app/stats/[name]/page.tsx`에 Lv.20 카드 기본값+성장치 표시 로직 추가
+
+## 관련 파일
+
+- `src/lib/stats-data.ts` - StatKey, STAT_CATEGORIES 수정
+- `src/types/patch.ts` - BaseStats 타입 (hpRegenBase/hpRegenGrowth)
+- `src/app/stats/page.tsx` - 스탯 비교 페이지 (동적으로 STAT_CATEGORIES 사용)
+- `src/app/stats/[name]/page.tsx` - 실험체 스탯 상세 페이지

--- a/scripts/compare-dakgg-stats.ts
+++ b/scripts/compare-dakgg-stats.ts
@@ -1,0 +1,278 @@
+/**
+ * dak.gg 크롤링 결과와 Firestore baseStats 비교
+ *
+ * 사용법:
+ *   npx tsx scripts/compare-dakgg-stats.ts            # 전체 비교
+ *   npx tsx scripts/compare-dakgg-stats.ts 나딘 가넷  # 특정 캐릭터만
+ *
+ * 출력:
+ *   - 콘솔: 차이 요약
+ *   - scripts/dakgg-compare-result.json: 상세 비교 결과
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { initFirebaseAdmin } from './lib/firebase-admin';
+import type { DakggCrawlResult, DakggWeaponStat } from './crawl-dakgg-stats';
+
+const DAKGG_PATH = path.join(__dirname, 'dakgg-stats-result.json');
+const OUTPUT_PATH = path.join(__dirname, 'dakgg-compare-result.json');
+
+// ─── 타입 ────────────────────────────────────────────────────
+
+type FirestoreWeaponStat = {
+  weaponType: string;
+  attackSpeedGrowth: number | null;
+  basicAttackAmpGrowth: number | null;
+  skillAmpGrowth: number | null;
+};
+
+type FirestoreBaseStats = {
+  hpBase: number | null;
+  hpGrowth: number | null;
+  hpRegenBase: number | null;
+  hpRegenGrowth: number | null;
+  defenseBase: number | null;
+  defenseGrowth: number | null;
+  attackBase: number | null;
+  attackGrowth: number | null;
+  attackSpeedBase: number | null;
+  moveSpeed: number | null;
+  weaponStats: FirestoreWeaponStat[];
+};
+
+type FieldDiff = {
+  field: string;
+  firestore: number | null;
+  dakgg: number | null;
+  status: 'missing_in_firestore' | 'different' | 'ok';
+};
+
+type WeaponDiff = {
+  weaponType: string; // 비교 기준 키
+  dakggKo: string;
+  firestoreMatch: boolean;
+  diffs: FieldDiff[];
+};
+
+type CharacterDiff = {
+  name: string;
+  dakggSlug: string;
+  baseStatDiffs: FieldDiff[];
+  weaponDiffs: WeaponDiff[];
+  hasNewFields: boolean; // hpRegen 등 Firestore에 없는 필드
+  hasValueDiffs: boolean; // 기존 필드 값 차이
+};
+
+type CompareResult = {
+  comparedAt: string;
+  dakggCrawledAt: string;
+  totalCompared: number;
+  withNewFields: number; // hpRegen 추가 필요한 캐릭터 수
+  withValueDiffs: number; // 값 차이 있는 캐릭터 수
+  skipped: string[]; // dak.gg 파싱 실패
+  characters: Record<string, CharacterDiff>;
+};
+
+// ─── 비교 로직 ────────────────────────────────────────────────
+
+function compareNum(
+  field: string,
+  fsVal: number | null | undefined,
+  dgVal: number | null
+): FieldDiff {
+  // Firestore에 필드 자체가 없는 경우 (undefined)
+  if (fsVal === undefined || fsVal === null) {
+    if (dgVal === null) return { field, firestore: null, dakgg: null, status: 'ok' };
+    return { field, firestore: null, dakgg: dgVal, status: 'missing_in_firestore' };
+  }
+  if (dgVal === null) return { field, firestore: fsVal, dakgg: null, status: 'ok' };
+
+  // 소수점 오차 허용 (0.001 이하)
+  const diff = Math.abs(fsVal - dgVal);
+  const status = diff > 0.001 ? 'different' : 'ok';
+  return { field, firestore: fsVal, dakgg: dgVal, status };
+}
+
+function compareWeaponStats(
+  fsWeapons: FirestoreWeaponStat[],
+  dgWeapons: DakggWeaponStat[]
+): WeaponDiff[] {
+  const result: WeaponDiff[] = [];
+
+  for (const dg of dgWeapons) {
+    // Firestore 무기 매핑: 한글명 기준 (dak.gg는 한글명만 사용)
+    const fs = fsWeapons.find((w) => w.weaponType === dg.weaponType);
+
+    const diffs: FieldDiff[] = [
+      compareNum('attackSpeedGrowth', fs?.attackSpeedGrowth, dg.attackSpeedGrowth),
+      compareNum('basicAttackAmpGrowth', fs?.basicAttackAmpGrowth, dg.basicAttackAmpGrowth),
+      compareNum('skillAmpGrowth', fs?.skillAmpGrowth, dg.skillAmpGrowth),
+    ].filter((d) => d.status !== 'ok');
+
+    result.push({
+      weaponType: dg.weaponType,
+      dakggKo: dg.weaponType,
+      firestoreMatch: !!fs,
+      diffs,
+    });
+  }
+
+  return result;
+}
+
+// ─── 메인 ────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (!fs.existsSync(DAKGG_PATH)) {
+    console.error(`dak.gg 결과 없음: ${DAKGG_PATH}`);
+    console.error('먼저 npx tsx scripts/crawl-dakgg-stats.ts 를 실행하세요.');
+    process.exit(1);
+  }
+
+  const raw = fs.readFileSync(DAKGG_PATH, 'utf-8');
+  const dakggResult: DakggCrawlResult = JSON.parse(raw);
+
+  // Firestore 로드
+  console.log('Firestore 데이터 로드 중...');
+  const db = initFirebaseAdmin();
+  const snapshot = await db.collection('characters').get();
+  const firestoreMap = new Map<string, FirestoreBaseStats | null>();
+  snapshot.forEach((doc) => {
+    const data = doc.data() as { baseStats?: FirestoreBaseStats };
+    firestoreMap.set(doc.id, data.baseStats ?? null);
+  });
+  console.log(`Firestore: ${firestoreMap.size}개 캐릭터 로드`);
+
+  const targets = args.length > 0 ? args : Object.keys(dakggResult.characters);
+
+  const compareResult: CompareResult = {
+    comparedAt: new Date().toISOString(),
+    dakggCrawledAt: dakggResult.crawledAt,
+    totalCompared: 0,
+    withNewFields: 0,
+    withValueDiffs: 0,
+    skipped: [],
+    characters: {},
+  };
+
+  for (const name of targets) {
+    const dg = dakggResult.characters[name];
+
+    if (!dg || dg.parseError) {
+      compareResult.skipped.push(`${name} (${dg?.parseError ?? '크롤링 안 됨'})`);
+      continue;
+    }
+
+    const fs = firestoreMap.get(name);
+
+    // 기본 스탯 비교
+    const baseStatDiffs: FieldDiff[] = [
+      compareNum('hpBase', fs?.hpBase, dg.hpBase),
+      compareNum('hpGrowth', fs?.hpGrowth, dg.hpGrowth),
+      compareNum('hpRegenBase (체력 재생)', fs?.hpRegenBase, dg.hpRegenBase),
+      compareNum('hpRegenGrowth', fs?.hpRegenGrowth, dg.hpRegenGrowth),
+      compareNum('defenseBase', fs?.defenseBase, dg.defenseBase),
+      compareNum('defenseGrowth', fs?.defenseGrowth, dg.defenseGrowth),
+      compareNum('attackBase', fs?.attackBase, dg.attackBase),
+      compareNum('attackGrowth', fs?.attackGrowth, dg.attackGrowth),
+      compareNum('attackSpeedBase', fs?.attackSpeedBase, dg.attackSpeedBase),
+      compareNum('moveSpeed', fs?.moveSpeed, dg.moveSpeed),
+    ].filter((d) => d.status !== 'ok');
+
+    // 무기 숙련도 비교
+    const weaponDiffs = compareWeaponStats(fs?.weaponStats ?? [], dg.weaponStats).filter(
+      (w) => !w.firestoreMatch || w.diffs.length > 0
+    );
+
+    const hasNewFields = baseStatDiffs.some((d) => d.status === 'missing_in_firestore');
+    const hasValueDiffs =
+      baseStatDiffs.some((d) => d.status === 'different') ||
+      weaponDiffs.some((w) => w.diffs.length > 0);
+
+    const charDiff: CharacterDiff = {
+      name,
+      dakggSlug: dg.dakggSlug,
+      baseStatDiffs,
+      weaponDiffs,
+      hasNewFields,
+      hasValueDiffs,
+    };
+
+    compareResult.characters[name] = charDiff;
+    compareResult.totalCompared++;
+    if (hasNewFields) compareResult.withNewFields++;
+    if (hasValueDiffs) compareResult.withValueDiffs++;
+  }
+
+  // ─── 콘솔 출력 ───────────────────────────────────────────────
+
+  console.log('\n' + '='.repeat(60));
+  console.log('dak.gg vs Firestore 비교 결과');
+  console.log('='.repeat(60));
+
+  let okCount = 0;
+
+  for (const [name, diff] of Object.entries(compareResult.characters)) {
+    if (!diff.hasNewFields && !diff.hasValueDiffs) {
+      okCount++;
+      continue;
+    }
+
+    console.log(`\n[ ${name} ] (${diff.dakggSlug})`);
+
+    // 새 필드 (체력 재생 등)
+    const missing = diff.baseStatDiffs.filter((d) => d.status === 'missing_in_firestore');
+    if (missing.length > 0) {
+      console.log('  📋 Firestore에 없는 필드:');
+      missing.forEach((d) => {
+        console.log(`     ${d.field}: ${d.dakgg} (dak.gg)`);
+      });
+    }
+
+    // 값 차이
+    const different = diff.baseStatDiffs.filter((d) => d.status === 'different');
+    if (different.length > 0) {
+      console.log('  ⚠️  기본 스탯 차이:');
+      different.forEach((d) => {
+        console.log(`     ${d.field}: FS=${d.firestore} / dak.gg=${d.dakgg}`);
+      });
+    }
+
+    // 무기 숙련도 차이
+    const weaponProblems = diff.weaponDiffs.filter((w) => !w.firestoreMatch || w.diffs.length > 0);
+    if (weaponProblems.length > 0) {
+      console.log('  🗡️  무기 숙련도 차이:');
+      weaponProblems.forEach((w) => {
+        if (!w.firestoreMatch) {
+          console.log(`     ${w.weaponType}: Firestore에 없는 무기 타입`);
+        } else {
+          w.diffs.forEach((d) => {
+            console.log(`     ${w.weaponType} / ${d.field}: FS=${d.firestore} / dak.gg=${d.dakgg}`);
+          });
+        }
+      });
+    }
+  }
+
+  console.log('\n' + '='.repeat(60));
+  console.log(`비교 완료: ${compareResult.totalCompared}개`);
+  console.log(`  ✅ 일치: ${okCount}개`);
+  console.log(`  📋 새 필드 필요: ${compareResult.withNewFields}개`);
+  console.log(`  ⚠️  값 차이: ${compareResult.withValueDiffs}개`);
+  if (compareResult.skipped.length > 0) {
+    console.log(`  ❌ 스킵: ${compareResult.skipped.length}개`);
+    compareResult.skipped.forEach((s) => console.log(`     ${s}`));
+  }
+  console.log('='.repeat(60));
+
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(compareResult, null, 2), 'utf-8');
+  console.log(`\n상세 결과 저장: ${OUTPUT_PATH}`);
+}
+
+main().catch((err) => {
+  console.error('오류:', err);
+  process.exit(1);
+});

--- a/scripts/crawl-dakgg-stats.ts
+++ b/scripts/crawl-dakgg-stats.ts
@@ -1,0 +1,364 @@
+/**
+ * dak.gg에서 실험체 기본 스텟 크롤링 (체력 재생 포함)
+ * 나무위키 크롤링 데이터와 크로스체크 용도
+ *
+ * dak.gg 테이블 구조 (단일 테이블):
+ *   항목         | 레벨 스탯(LV.1) | 성장치
+ *   공격력       | 35              | 4.1
+ *   체력 재생    | 2               | 0.136
+ *   이동 속도    | 3.55            |
+ *   방망이                          ← 무기명 (단독 행)
+ *   공격 속도    | 3%              | 3%
+ *   스킬 증폭    | 4.4%            | 4.4%
+ *
+ * 사용법:
+ *   npx tsx scripts/crawl-dakgg-stats.ts              # 전체 크롤링
+ *   npx tsx scripts/crawl-dakgg-stats.ts 나딘 가넷    # 특정 캐릭터만
+ */
+
+import puppeteer, { type Browser, type Page } from 'puppeteer';
+import { initFirebaseAdmin } from './lib/firebase-admin';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BASE_URL = 'https://dak.gg/er';
+
+// ─── 타입 정의 ───────────────────────────────────────────────
+
+export type DakggWeaponStat = {
+  weaponType: string; // 한글 무기 타입 (e.g. "활", "방망이")
+  attackSpeedGrowth: number | null;
+  basicAttackAmpGrowth: number | null;
+  skillAmpGrowth: number | null;
+};
+
+export type DakggCharacterStats = {
+  nameKo: string; // dak.gg에서 읽은 한글명
+  firestoreName: string | null; // Firestore 문서 ID
+  dakggSlug: string; // URL 슬러그
+  hpBase: number | null;
+  hpGrowth: number | null;
+  hpRegenBase: number | null; // 체력 재생 (나무위키 크롤링 누락 필드)
+  hpRegenGrowth: number | null;
+  defenseBase: number | null;
+  defenseGrowth: number | null;
+  attackBase: number | null;
+  attackGrowth: number | null;
+  attackSpeedBase: number | null;
+  moveSpeed: number | null;
+  weaponStats: DakggWeaponStat[];
+  crawledAt: string;
+  parseError?: string;
+};
+
+export type DakggCrawlResult = {
+  crawledAt: string;
+  totalCount: number;
+  successCount: number;
+  failCount: number;
+  slugMapping: Record<string, string>; // 한글명 → 슬러그
+  characters: Record<string, DakggCharacterStats>; // Firestore 한글명 기준
+};
+
+// ─── Firestore 캐릭터 목록 ────────────────────────────────────
+
+async function loadFirestoreNames(): Promise<string[]> {
+  const db = initFirebaseAdmin();
+  const snapshot = await db.collection('characters').select().get();
+  return snapshot.docs.map((doc) => doc.id).sort((a, b) => a.localeCompare(b));
+}
+
+// ─── 슬러그 매핑 ─────────────────────────────────────────────
+
+async function buildSlugMapping(page: Page): Promise<Record<string, string>> {
+  console.log('dak.gg 캐릭터 목록 로드 중...');
+  await page.goto(`${BASE_URL}/characters`, { waitUntil: 'networkidle2', timeout: 30000 });
+  await page.waitForSelector('img[alt]', { timeout: 15000 }).catch(() => null);
+
+  const mapping = await page.evaluate((): Record<string, string> => {
+    const result: Record<string, string> = {};
+    const links = document.querySelectorAll<HTMLAnchorElement>('a[href*="/er/characters/"]');
+    links.forEach((link) => {
+      const href = link.getAttribute('href') ?? '';
+      const match = href.match(/^\/er\/characters\/([^/]+)$/);
+      if (!match) return;
+      const slug = match[1];
+      const img = link.querySelector('img[alt]');
+      const nameKo = img?.getAttribute('alt')?.trim() ?? '';
+      if (slug && nameKo) result[nameKo] = slug;
+    });
+    return result;
+  });
+
+  console.log(`슬러그 매핑 완료: ${Object.keys(mapping).length}개`);
+  return mapping;
+}
+
+// ─── 소개 페이지 파싱 ─────────────────────────────────────────
+
+async function parseIntroductionPage(
+  page: Page,
+  slug: string,
+  firestoreName: string
+): Promise<DakggCharacterStats> {
+  const result: DakggCharacterStats = {
+    nameKo: '',
+    firestoreName,
+    dakggSlug: slug,
+    hpBase: null,
+    hpGrowth: null,
+    hpRegenBase: null,
+    hpRegenGrowth: null,
+    defenseBase: null,
+    defenseGrowth: null,
+    attackBase: null,
+    attackGrowth: null,
+    attackSpeedBase: null,
+    moveSpeed: null,
+    weaponStats: [],
+    crawledAt: new Date().toISOString(),
+  };
+
+  try {
+    const url = `${BASE_URL}/characters/${slug}/introduction`;
+    await page.goto(url, { waitUntil: 'networkidle2', timeout: 30000 });
+
+    // 리다이렉트 감지 (잘못된 슬러그 → 다른 캐릭터로 이동)
+    const currentUrl = page.url();
+    const currentSlug = currentUrl.match(/\/characters\/([^/?#]+)/)?.[1] ?? '';
+    if (currentSlug.toLowerCase() !== slug.toLowerCase()) {
+      result.parseError = `리다이렉트: ${slug} → ${currentSlug}`;
+      return result;
+    }
+
+    // 스탯 테이블 로드 대기
+    const loaded = await page
+      .waitForFunction(
+        (): boolean =>
+          document.body.innerText.includes('체력 재생') &&
+          document.body.innerText.includes('이동 속도'),
+        { timeout: 15000 }
+      )
+      .then(() => true)
+      .catch(() => false);
+
+    if (!loaded) {
+      result.parseError = '스탯 테이블 로드 타임아웃';
+      return result;
+    }
+
+    // 테이블 전체 행 추출
+    const tableRows = await page.evaluate((): string[][] => {
+      const tables = [...document.querySelectorAll('table')];
+      for (const table of tables) {
+        const rows = [...table.querySelectorAll('tr')].map((tr) =>
+          [...tr.querySelectorAll('td, th')].map((c) => (c as HTMLElement).innerText.trim())
+        );
+        const flat = rows.flat().join(' ');
+        // 기본 스탯 + 무기 숙련도가 모두 있는 테이블
+        if (flat.includes('체력 재생') && flat.includes('이동 속도')) {
+          return rows;
+        }
+      }
+      return [];
+    });
+
+    if (tableRows.length === 0) {
+      result.parseError = '스탯 테이블 없음';
+      return result;
+    }
+
+    // 순차 파싱: 기본 스탯 → 무기 숙련도
+    let currentWeapon: DakggWeaponStat | null = null;
+
+    for (const row of tableRows) {
+      const label = row[0]?.trim() ?? '';
+      if (!label || label === '항목') continue;
+
+      const vals = row.slice(1).filter((v) => v.length > 0);
+
+      // 무기명 행: 셀이 하나이고 한글/영문 이름 (숫자/% 없음)
+      if (row.length === 1 && !/[\d%]/.test(label)) {
+        if (currentWeapon) result.weaponStats.push(currentWeapon);
+        currentWeapon = {
+          weaponType: label,
+          attackSpeedGrowth: null,
+          basicAttackAmpGrowth: null,
+          skillAmpGrowth: null,
+        };
+        continue;
+      }
+
+      // 무기 숙련도 행: 현재 무기가 있고 % 값 포함
+      if (currentWeapon && vals.some((v) => v.includes('%'))) {
+        if (label.includes('공격 속도') || label.includes('공격속도')) {
+          const m = vals[0]?.match(/(\d+(?:\.\d+)?)/);
+          if (m) currentWeapon.attackSpeedGrowth = parseFloat(m[1]);
+        } else if (label.includes('기본 공격 증폭') || label.includes('기본공격증폭')) {
+          const m = vals[0]?.match(/(\d+(?:\.\d+)?)/);
+          if (m) currentWeapon.basicAttackAmpGrowth = parseFloat(m[1]);
+        } else if (label.includes('스킬 증폭') || label.includes('스킬증폭')) {
+          const m = vals[0]?.match(/(\d+(?:\.\d+)?)/);
+          if (m) currentWeapon.skillAmpGrowth = parseFloat(m[1]);
+        }
+        continue;
+      }
+
+      // 기본 스탯 행
+      if ((label === '체력' || label === '최대 체력') && result.hpBase === null) {
+        result.hpBase = parseNum(vals[0]);
+        result.hpGrowth = parseNum(vals[1]);
+      } else if (label === '체력 재생' && result.hpRegenBase === null) {
+        result.hpRegenBase = parseNum(vals[0]);
+        result.hpRegenGrowth = parseNum(vals[1]);
+      } else if (label === '방어력' && result.defenseBase === null) {
+        result.defenseBase = parseNum(vals[0]);
+        result.defenseGrowth = parseNum(vals[1]);
+      } else if (label === '공격력' && result.attackBase === null) {
+        result.attackBase = parseNum(vals[0]);
+        result.attackGrowth = parseNum(vals[1]);
+      } else if (
+        (label === '공격 속도' || label === '공격속도') &&
+        result.attackSpeedBase === null
+      ) {
+        result.attackSpeedBase = parseNum(vals[0]);
+      } else if ((label === '이동 속도' || label === '이동속도') && result.moveSpeed === null) {
+        result.moveSpeed = parseNum(vals[0]);
+      }
+    }
+
+    if (currentWeapon) result.weaponStats.push(currentWeapon);
+
+    if (result.hpBase === null && result.defenseBase === null && result.attackBase === null) {
+      result.parseError = '기본 스탯 파싱 실패 (값 없음)';
+    }
+  } catch (err) {
+    result.parseError = err instanceof Error ? err.message : String(err);
+  }
+
+  return result;
+}
+
+// ─── 헬퍼 ────────────────────────────────────────────────────
+
+function parseNum(text: string | undefined): number | null {
+  if (!text) return null;
+  const cleaned = text.replace(/[+%,]/g, '').trim();
+  const n = parseFloat(cleaned);
+  return isNaN(n) ? null : n;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ─── 메인 ────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  const browser: Browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page: Page = await browser.newPage();
+    await page.setUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    );
+    await page.setExtraHTTPHeaders({ 'Accept-Language': 'ko-KR,ko;q=0.9' });
+
+    // tsx/esbuild가 page.evaluate 내부 함수에 추가하는 __name 헬퍼 폴리필
+    await page.evaluateOnNewDocument(() => {
+      // @ts-expect-error esbuild polyfill
+      if (typeof globalThis.__name === 'undefined') globalThis.__name = (fn: unknown) => fn;
+    });
+
+    // 슬러그 매핑 구축
+    const slugMapping = await buildSlugMapping(page);
+
+    // Firestore 캐릭터 목록
+    console.log('Firestore 캐릭터 목록 로드 중...');
+    const firestoreNames = await loadFirestoreNames();
+    console.log(`Firestore: ${firestoreNames.length}개`);
+
+    const targets = args.length > 0 ? args : firestoreNames;
+    console.log(`\n크롤링 대상: ${targets.length}개\n`);
+
+    const crawlResult: DakggCrawlResult = {
+      crawledAt: new Date().toISOString(),
+      totalCount: targets.length,
+      successCount: 0,
+      failCount: 0,
+      slugMapping,
+      characters: {},
+    };
+
+    for (let i = 0; i < targets.length; i++) {
+      const name = targets[i];
+      const slug = slugMapping[name];
+
+      process.stdout.write(`[${i + 1}/${targets.length}] ${name}`);
+
+      if (!slug) {
+        console.log(' → 슬러그 없음');
+        crawlResult.characters[name] = {
+          nameKo: name,
+          firestoreName: name,
+          dakggSlug: '',
+          hpBase: null,
+          hpGrowth: null,
+          hpRegenBase: null,
+          hpRegenGrowth: null,
+          defenseBase: null,
+          defenseGrowth: null,
+          attackBase: null,
+          attackGrowth: null,
+          attackSpeedBase: null,
+          moveSpeed: null,
+          weaponStats: [],
+          crawledAt: new Date().toISOString(),
+          parseError: 'dak.gg 목록에 없음',
+        };
+        crawlResult.failCount++;
+        continue;
+      }
+
+      process.stdout.write(` (${slug})...`);
+      const stats = await parseIntroductionPage(page, slug, name);
+      crawlResult.characters[name] = stats;
+
+      if (stats.parseError) {
+        crawlResult.failCount++;
+        console.log(` 실패: ${stats.parseError}`);
+      } else {
+        crawlResult.successCount++;
+        const weapons = stats.weaponStats.map((w) => w.weaponType).join('/');
+        console.log(
+          ` 완료 (HP:${stats.hpBase} 재생:${stats.hpRegenBase} DEF:${stats.defenseBase} ATK:${stats.attackBase} 무기:${weapons || '-'})`
+        );
+      }
+
+      if (i < targets.length - 1) await delay(1000);
+    }
+
+    const outputPath = path.join(process.cwd(), 'scripts', 'dakgg-stats-result.json');
+    fs.writeFileSync(outputPath, JSON.stringify(crawlResult, null, 2), 'utf-8');
+
+    console.log(
+      `\n결과: 성공 ${crawlResult.successCount} / 실패 ${crawlResult.failCount} / 총 ${crawlResult.totalCount}`
+    );
+    console.log(`저장: ${outputPath}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+const scriptName = process.argv[1] ?? '';
+if (scriptName.endsWith('crawl-dakgg-stats.ts') || scriptName.endsWith('crawl-dakgg-stats.js')) {
+  main().catch((err) => {
+    console.error('치명적 오류:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/upload-dakgg-stats.ts
+++ b/scripts/upload-dakgg-stats.ts
@@ -1,0 +1,132 @@
+/**
+ * dak.gg 크롤링 결과를 Firestore characters/{name}.baseStats에 반영
+ * - 체력 재생(hpRegenBase, hpRegenGrowth) 신규 필드 추가
+ * - dak.gg 기준으로 기존 스탯 값 정정
+ * - 무기 숙련도 차이도 반영
+ *
+ * 사용법:
+ *   npx tsx scripts/upload-dakgg-stats.ts              # 전체 업로드
+ *   npx tsx scripts/upload-dakgg-stats.ts --dry-run    # 미리보기 (저장 안 함)
+ *   npx tsx scripts/upload-dakgg-stats.ts 나딘 가넷    # 특정 캐릭터만
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { initFirebaseAdmin } from './lib/firebase-admin';
+import type { DakggCrawlResult, DakggCharacterStats } from './crawl-dakgg-stats';
+
+const DAKGG_PATH = path.join(__dirname, 'dakgg-stats-result.json');
+
+type BaseStatsFirestore = {
+  hpBase: number | null;
+  hpGrowth: number | null;
+  hpRegenBase: number | null;
+  hpRegenGrowth: number | null;
+  defenseBase: number | null;
+  defenseGrowth: number | null;
+  attackBase: number | null;
+  attackGrowth: number | null;
+  attackSpeedBase: number | null;
+  moveSpeed: number | null;
+  weaponStats: Array<{
+    weaponType: string;
+    attackSpeedGrowth: number | null;
+    basicAttackAmpGrowth: number | null;
+    skillAmpGrowth: number | null;
+  }>;
+  crawledAt: string;
+};
+
+function toFirestoreStats(dg: DakggCharacterStats): BaseStatsFirestore {
+  return {
+    hpBase: dg.hpBase,
+    hpGrowth: dg.hpGrowth,
+    hpRegenBase: dg.hpRegenBase,
+    hpRegenGrowth: dg.hpRegenGrowth,
+    defenseBase: dg.defenseBase,
+    defenseGrowth: dg.defenseGrowth,
+    attackBase: dg.attackBase,
+    attackGrowth: dg.attackGrowth,
+    attackSpeedBase: dg.attackSpeedBase,
+    moveSpeed: dg.moveSpeed,
+    weaponStats: dg.weaponStats.map((w) => ({
+      weaponType: w.weaponType,
+      attackSpeedGrowth: w.attackSpeedGrowth,
+      basicAttackAmpGrowth: w.basicAttackAmpGrowth,
+      skillAmpGrowth: w.skillAmpGrowth,
+    })),
+    crawledAt: dg.crawledAt,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+  const dryRun = process.argv.includes('--dry-run');
+
+  if (!fs.existsSync(DAKGG_PATH)) {
+    console.error(`dak.gg 크롤링 결과 없음: ${DAKGG_PATH}`);
+    console.error('먼저 npx tsx scripts/crawl-dakgg-stats.ts 를 실행하세요.');
+    process.exit(1);
+  }
+
+  const raw = fs.readFileSync(DAKGG_PATH, 'utf-8');
+  const dakggResult: DakggCrawlResult = JSON.parse(raw);
+
+  const allEntries = Object.entries(dakggResult.characters);
+  const valid = allEntries.filter(([, c]) => !c.parseError);
+  const failed = allEntries.filter(([, c]) => c.parseError);
+
+  const targets = args.length > 0 ? valid.filter(([name]) => args.includes(name)) : valid;
+
+  console.log(`dak.gg 크롤링 결과: ${valid.length}명 성공 / ${failed.length}명 실패`);
+  if (failed.length > 0) {
+    console.log('실패 (건너뜀):');
+    failed.forEach(([name, c]) => console.log(`  - ${name}: ${c.parseError}`));
+  }
+  console.log(`업로드 대상: ${targets.length}명\n`);
+
+  if (dryRun) {
+    console.log('[DRY RUN] 미리보기 (실제 저장 안 함):');
+    targets.slice(0, 5).forEach(([name, c]) => {
+      const s = toFirestoreStats(c);
+      const weapons = s.weaponStats.map((w) => w.weaponType).join('/');
+      console.log(
+        `  ${name}: HP ${s.hpBase}+${s.hpGrowth}, 재생 ${s.hpRegenBase}+${s.hpRegenGrowth}, DEF ${s.defenseBase}, ATK ${s.attackBase}, 무기 ${weapons}`
+      );
+    });
+    if (targets.length > 5) console.log(`  ... 외 ${targets.length - 5}명`);
+    return;
+  }
+
+  const db = initFirebaseAdmin();
+  console.log('Firebase 업로드 시작...\n');
+
+  const batchSize = 500;
+  let uploaded = 0;
+
+  for (let i = 0; i < targets.length; i += batchSize) {
+    const batch = db.batch();
+    const chunk = targets.slice(i, i + batchSize);
+
+    for (const [name, charData] of chunk) {
+      const docRef = db.collection('characters').doc(name);
+      batch.update(docRef, { baseStats: toFirestoreStats(charData) });
+    }
+
+    await batch.commit();
+    uploaded += chunk.length;
+    console.log(`  ${uploaded}/${targets.length} 완료`);
+  }
+
+  console.log('\n' + '='.repeat(50));
+  console.log('업로드 완료');
+  console.log('='.repeat(50));
+  console.log(`저장: ${uploaded}명`);
+  console.log(`건너뜀 (파싱 실패): ${failed.length}명`);
+  console.log(`크롤링 시각: ${dakggResult.crawledAt}`);
+}
+
+main().catch((err) => {
+  console.error('오류:', err);
+  process.exit(1);
+});

--- a/src/app/stats/[name]/page.tsx
+++ b/src/app/stats/[name]/page.tsx
@@ -8,6 +8,7 @@ import {
   getWeaponStatRanking,
   getCharacterWeaponRank,
   getRankForWeaponCombo,
+  type StatComponents,
 } from '@/lib/stats-data';
 import { loadImageMap } from '@/lib/patch-data';
 import CharacterImage from '@/components/CharacterImage';
@@ -37,6 +38,7 @@ type StatCardData = {
   statKey: string;
   value: number;
   growth: number | null;
+  components: StatComponents | null;
   rankInfo: { rank: number; total: number } | undefined;
   minVal: number;
   maxVal: number;
@@ -86,6 +88,7 @@ export default async function StatsDetailPage({ params }: Props): Promise<React.
         statKey: config.key,
         value,
         growth: config.getGrowth(character.baseStats),
+        components: config.getComponents ? config.getComponents(character.baseStats) : null,
         rankInfo,
         minVal: validValues[0] ?? 0,
         maxVal: validValues[validValues.length - 1] ?? 1,
@@ -129,8 +132,21 @@ export default async function StatsDetailPage({ params }: Props): Promise<React.
         {/* 값 */}
         <p className={`font-mono text-3xl font-black ${d.textClass}`}>{d.formatValue(d.value)}</p>
 
-        {/* 성장치 */}
-        {d.growth !== null && (
+        {/* Lv.20 구성요소: 기본값 + 성장치 */}
+        {d.components && d.components.base !== null && d.components.growth !== null && (
+          <p className="mt-1 text-xs text-zinc-500">
+            <span className="font-mono text-zinc-400">
+              {d.components.formatBase(d.components.base)}
+            </span>{' '}
+            기본 <span className="text-zinc-600">·</span> 레벨당{' '}
+            <span className="font-mono text-zinc-400">
+              +{d.components.formatGrowth(d.components.growth)}
+            </span>
+          </p>
+        )}
+
+        {/* 성장치 (기본 스탯용) */}
+        {d.growth !== null && !d.components && (
           <p className="mt-1 text-xs text-zinc-500">
             레벨당 <span className="font-mono text-zinc-400">+{d.growth}</span>
           </p>

--- a/src/lib/stats-data.ts
+++ b/src/lib/stats-data.ts
@@ -13,9 +13,11 @@ export type StatKey =
   | 'defense'
   | 'moveSpeed'
   | 'attackSpeed'
+  | 'hpRegen'
   | 'hp20'
   | 'attack20'
   | 'defense20'
+  | 'hpRegen20'
   | 'attackSpeedGrowth'
   | 'basicAttackAmpGrowth'
   | 'skillAmpGrowth';
@@ -30,6 +32,13 @@ export type WeaponStatEntry = {
 
 export type StatSection = 'base' | 'lv20' | 'weapon';
 
+export type StatComponents = {
+  base: number | null;
+  growth: number | null;
+  formatBase: (v: number) => string;
+  formatGrowth: (v: number) => string;
+};
+
 export type StatConfig = {
   key: StatKey;
   label: string;
@@ -40,6 +49,7 @@ export type StatConfig = {
   bgClass: string;
   getValue: (stats: BaseStats) => number | null;
   getGrowth: (stats: BaseStats) => number | null;
+  getComponents?: (stats: BaseStats) => StatComponents;
   formatValue: (v: number) => string;
   weaponStatKey?: WeaponStatKey;
 };
@@ -47,7 +57,11 @@ export type StatConfig = {
 const defaultFormat = (v: number): string => String(v);
 const decimalFormat = (v: number): string => v.toFixed(2);
 const percentFormat = (v: number): string => `${v}%`;
-const roundedFormat = (v: number): string => Math.round(v).toLocaleString('ko-KR');
+// Lv.20 스탯 포맷: 소수점이 있으면 1자리, 정수면 한국 표기
+const lv20Format = (v: number): string => {
+  const r = Math.round(v * 10) / 10;
+  return Number.isInteger(r) ? r.toLocaleString('ko-KR') : r.toFixed(1);
+};
 
 const lv20 = (base: number | null, growth: number | null): number | null =>
   base !== null && growth !== null ? base + growth * 19 : null;
@@ -122,6 +136,18 @@ export const STAT_CATEGORIES: StatConfig[] = [
     getGrowth: () => null,
     formatValue: decimalFormat,
   },
+  {
+    key: 'hpRegen',
+    label: '체력 재생',
+    description: '레벨 1 기본 체력 재생',
+    section: 'base',
+    barClass: 'from-green-500 to-green-400',
+    textClass: 'text-green-400',
+    bgClass: 'bg-green-500/10',
+    getValue: (s) => s.hpRegenBase,
+    getGrowth: (s) => s.hpRegenGrowth,
+    formatValue: decimalFormat,
+  },
   // ── 레벨 20 최종 스텟 ─────────────────────────
   {
     key: 'hp20',
@@ -133,7 +159,13 @@ export const STAT_CATEGORIES: StatConfig[] = [
     bgClass: 'bg-teal-500/10',
     getValue: (s) => lv20(s.hpBase, s.hpGrowth),
     getGrowth: () => null,
-    formatValue: roundedFormat,
+    getComponents: (s) => ({
+      base: s.hpBase,
+      growth: s.hpGrowth,
+      formatBase: defaultFormat,
+      formatGrowth: defaultFormat,
+    }),
+    formatValue: lv20Format,
   },
   {
     key: 'attack20',
@@ -145,7 +177,13 @@ export const STAT_CATEGORIES: StatConfig[] = [
     bgClass: 'bg-pink-500/10',
     getValue: (s) => lv20(s.attackBase, s.attackGrowth),
     getGrowth: () => null,
-    formatValue: roundedFormat,
+    getComponents: (s) => ({
+      base: s.attackBase,
+      growth: s.attackGrowth,
+      formatBase: defaultFormat,
+      formatGrowth: defaultFormat,
+    }),
+    formatValue: lv20Format,
   },
   {
     key: 'defense20',
@@ -157,7 +195,31 @@ export const STAT_CATEGORIES: StatConfig[] = [
     bgClass: 'bg-blue-500/10',
     getValue: (s) => lv20(s.defenseBase, s.defenseGrowth),
     getGrowth: () => null,
-    formatValue: roundedFormat,
+    getComponents: (s) => ({
+      base: s.defenseBase,
+      growth: s.defenseGrowth,
+      formatBase: defaultFormat,
+      formatGrowth: defaultFormat,
+    }),
+    formatValue: lv20Format,
+  },
+  {
+    key: 'hpRegen20',
+    label: '체력 재생 (Lv.20)',
+    description: '레벨 20 체력 재생 · 기본 + 성장 × 19',
+    section: 'lv20',
+    barClass: 'from-lime-500 to-lime-400',
+    textClass: 'text-lime-400',
+    bgClass: 'bg-lime-500/10',
+    getValue: (s) => lv20(s.hpRegenBase, s.hpRegenGrowth),
+    getGrowth: () => null,
+    getComponents: (s) => ({
+      base: s.hpRegenBase,
+      growth: s.hpRegenGrowth,
+      formatBase: decimalFormat,
+      formatGrowth: decimalFormat,
+    }),
+    formatValue: lv20Format,
   },
   // ── 무기 성장치 (캐릭터 × 무기군 조합 랭킹) ──
   {

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -122,6 +122,8 @@ export type WeaponStat = {
 export type BaseStats = {
   hpBase: number | null;
   hpGrowth: number | null;
+  hpRegenBase: number | null;
+  hpRegenGrowth: number | null;
   defenseBase: number | null;
   defenseGrowth: number | null;
   attackBase: number | null;


### PR DESCRIPTION

## 관련 이슈

closes #97

## 변경 사항

- dak.gg 크롤링 스크립트 추가 (crawl-dakgg-stats.ts)
- Firestore 비교 스크립트 추가 (compare-dakgg-stats.ts)
- dak.gg 데이터 업로드 스크립트 추가 (upload-dakgg-stats.ts)
- BaseStats 타입에 hpRegenBase/hpRegenGrowth 필드 추가
- 스탯 비교 페이지에 체력 재생(Lv.1/Lv.20) 표시 추가
- Lv.20 스탯 소수점 표기 수정 (반올림 → 소수점 1자리)
- Lv.20 스탯 카드에 기본값 + 성장치 breakdown 표시


## 변경 유형

- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
