### PR TITLE
[feat] 실험체 스탯 관리자 페이지 추가

### DIFF
--- a/docs/work-logs/2026-04-23-실험체스탯관리자페이지.md
+++ b/docs/work-logs/2026-04-23-실험체스탯관리자페이지.md
@@ -1,0 +1,47 @@
+# 실험체 스탯 관리자 페이지
+
+## 개요
+
+- **시작일**: 2026-04-23
+- **상태**: 완료
+- **관련 브랜치**: feature/99
+
+## 목표
+
+- [x] 실험체 추가 (이름, 무기 역할군 1개 이상, 기본 스탯 입력)
+- [x] 실험체 스탯 수정 (기본 스탯 + 무기 스탯 편집)
+- [x] 실험체 스탯 항목 삭제 (무기 스탯 삭제, 경고 포함)
+- [x] 관리자 헤더에 "스탯 관리" 메뉴 추가
+
+## 진행 상황
+
+### 2026-04-23
+
+- 작업 시작
+- 기존 코드 구조 파악 완료 (admin-utils.ts, stats-data.ts, BaseStats 타입)
+- 무기 타입 목록 확인 (23종)
+
+## 실행 스크립트
+
+해당 없음 (프론트엔드/API 작업)
+
+## 중단 시 이어서 할 작업
+
+- [ ] API 라우트 구현
+- [ ] 페이지 및 컴포넌트 구현
+
+## 관련 파일
+
+- `src/types/patch.ts` - BaseStats, WeaponStat 타입
+- `src/lib/stats-data.ts` - loadAllStats, STAT_CATEGORIES
+- `src/lib/admin-utils.ts` - verifyAdmin, invalidateBalanceCache
+- `src/app/api/admin/characters/route.ts` (신규)
+- `src/app/api/admin/characters/[name]/stats/route.ts` (신규)
+- `src/app/api/admin/characters/[name]/stats/weapons/route.ts` (신규)
+- `src/app/api/admin/characters/[name]/stats/weapons/[weaponType]/route.ts` (신규)
+- `src/app/admin/stats/page.tsx` (신규)
+- `src/app/admin/stats/[name]/page.tsx` (신규)
+- `src/components/admin/AdminStatsList.tsx` (신규)
+- `src/components/admin/CharacterStatEditor.tsx` (신규)
+- `src/components/admin/AddCharacterModal.tsx` (신규)
+- `src/components/admin/AdminHeader.tsx` (수정)

--- a/src/app/admin/stats/[name]/page.tsx
+++ b/src/app/admin/stats/[name]/page.tsx
@@ -1,0 +1,54 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { db } from '@/lib/firebase-admin';
+import { CharacterStatEditor } from '@/components/admin/CharacterStatEditor';
+import type { BaseStats } from '@/types/patch';
+
+type PageProps = {
+  params: Promise<{ name: string }>;
+};
+
+type CharacterDoc = {
+  name: string;
+  baseStats?: BaseStats;
+};
+
+export default async function AdminStatsDetailPage({
+  params,
+}: PageProps): Promise<React.JSX.Element> {
+  const { name } = await params;
+  const decodedName = decodeURIComponent(name);
+
+  const docRef = db.collection('characters').doc(decodedName);
+  const doc = await docRef.get();
+
+  if (!doc.exists) {
+    notFound();
+  }
+
+  const data = doc.data() as CharacterDoc;
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <div className="mb-6">
+        <Link
+          href="/admin/stats"
+          className="text-sm text-gray-400 hover:text-white transition-colors"
+        >
+          ← 스탯 관리 목록으로
+        </Link>
+      </div>
+
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-white">{decodedName} — 스탯 편집</h1>
+        {!data.baseStats && (
+          <p className="mt-2 text-amber-400 text-sm">
+            스탯 데이터가 없습니다. 아래에서 입력하세요.
+          </p>
+        )}
+      </div>
+
+      <CharacterStatEditor characterName={decodedName} initialStats={data.baseStats ?? null} />
+    </div>
+  );
+}

--- a/src/app/admin/stats/page.tsx
+++ b/src/app/admin/stats/page.tsx
@@ -1,0 +1,25 @@
+import { loadAllStats } from '@/lib/stats-data';
+import { loadBalanceData, extractCharacters } from '@/lib/patch-data';
+import { AdminStatsList } from '@/components/admin/AdminStatsList';
+
+export default async function AdminStatsPage(): Promise<React.JSX.Element> {
+  const [entries, balanceData] = await Promise.all([loadAllStats(), loadBalanceData()]);
+
+  const allCharacters = extractCharacters(balanceData);
+  const allCharacterNames = [...allCharacters]
+    .sort((a, b) => a.name.localeCompare(b.name, 'ko'))
+    .map((c) => c.name);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-white mb-2">실험체 스탯 관리</h1>
+        <p className="text-gray-400">
+          총 {allCharacterNames.length}명 · 스탯 데이터 있음 {entries.length}명
+        </p>
+      </div>
+
+      <AdminStatsList entries={entries} allCharacterNames={allCharacterNames} />
+    </div>
+  );
+}

--- a/src/app/api/admin/characters/[name]/stats/route.ts
+++ b/src/app/api/admin/characters/[name]/stats/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/firebase-admin';
+import { verifyAdmin, invalidateStatsCache } from '@/lib/admin-utils';
+import type { BaseStats } from '@/types/patch';
+
+type BaseStatsScalar = Omit<BaseStats, 'weaponStats' | 'crawledAt'>;
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> }
+): Promise<NextResponse> {
+  try {
+    const authHeader = request.headers.get('Authorization');
+    const isAdmin = await verifyAdmin(authHeader);
+
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { name } = await params;
+    const characterName = decodeURIComponent(name);
+
+    const docRef = db.collection('characters').doc(characterName);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    const data = doc.data();
+    return NextResponse.json({ baseStats: data?.baseStats ?? null });
+  } catch (error) {
+    console.error('Stats GET error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> }
+): Promise<NextResponse> {
+  try {
+    const authHeader = request.headers.get('Authorization');
+    const isAdmin = await verifyAdmin(authHeader);
+
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { name } = await params;
+    const characterName = decodeURIComponent(name);
+
+    const body = (await request.json()) as BaseStatsScalar;
+
+    const docRef = db.collection('characters').doc(characterName);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    const data = doc.data();
+    const currentStats: BaseStats = data?.baseStats ?? {};
+
+    await docRef.update({
+      'baseStats.hpBase': body.hpBase ?? currentStats.hpBase,
+      'baseStats.hpGrowth': body.hpGrowth ?? currentStats.hpGrowth,
+      'baseStats.hpRegenBase': body.hpRegenBase ?? currentStats.hpRegenBase,
+      'baseStats.hpRegenGrowth': body.hpRegenGrowth ?? currentStats.hpRegenGrowth,
+      'baseStats.defenseBase': body.defenseBase ?? currentStats.defenseBase,
+      'baseStats.defenseGrowth': body.defenseGrowth ?? currentStats.defenseGrowth,
+      'baseStats.attackBase': body.attackBase ?? currentStats.attackBase,
+      'baseStats.attackGrowth': body.attackGrowth ?? currentStats.attackGrowth,
+      'baseStats.attackSpeedBase': body.attackSpeedBase ?? currentStats.attackSpeedBase,
+      'baseStats.moveSpeed': body.moveSpeed ?? currentStats.moveSpeed,
+    });
+
+    invalidateStatsCache();
+
+    return NextResponse.json({ success: true, message: '스탯이 수정되었습니다.' });
+  } catch (error) {
+    console.error('Stats PUT error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/characters/[name]/stats/weapons/[weaponType]/route.ts
+++ b/src/app/api/admin/characters/[name]/stats/weapons/[weaponType]/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/firebase-admin';
+import { verifyAdmin, invalidateStatsCache } from '@/lib/admin-utils';
+import type { WeaponStat, BaseStats } from '@/types/patch';
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ name: string; weaponType: string }> }
+): Promise<NextResponse> {
+  try {
+    const authHeader = request.headers.get('Authorization');
+    const isAdmin = await verifyAdmin(authHeader);
+
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { name, weaponType } = await params;
+    const characterName = decodeURIComponent(name);
+    const decodedWeaponType = decodeURIComponent(weaponType);
+    const body = (await request.json()) as Partial<Omit<WeaponStat, 'weaponType'>>;
+
+    const docRef = db.collection('characters').doc(characterName);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    const data = doc.data();
+    const currentStats: BaseStats = data?.baseStats ?? {};
+    const weaponStats: WeaponStat[] = currentStats.weaponStats ?? [];
+
+    const idx = weaponStats.findIndex((w) => w.weaponType === decodedWeaponType);
+    if (idx === -1) {
+      return NextResponse.json({ error: 'Weapon stat not found' }, { status: 404 });
+    }
+
+    weaponStats[idx] = {
+      ...weaponStats[idx],
+      attackSpeedGrowth:
+        body.attackSpeedGrowth !== undefined
+          ? body.attackSpeedGrowth
+          : weaponStats[idx].attackSpeedGrowth,
+      basicAttackAmpGrowth:
+        body.basicAttackAmpGrowth !== undefined
+          ? body.basicAttackAmpGrowth
+          : weaponStats[idx].basicAttackAmpGrowth,
+      skillAmpGrowth:
+        body.skillAmpGrowth !== undefined ? body.skillAmpGrowth : weaponStats[idx].skillAmpGrowth,
+    };
+
+    await docRef.update({ 'baseStats.weaponStats': weaponStats });
+
+    invalidateStatsCache();
+
+    return NextResponse.json({ success: true, message: '무기 스탯이 수정되었습니다.' });
+  } catch (error) {
+    console.error('Weapon stat PUT error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ name: string; weaponType: string }> }
+): Promise<NextResponse> {
+  try {
+    const authHeader = request.headers.get('Authorization');
+    const isAdmin = await verifyAdmin(authHeader);
+
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { name, weaponType } = await params;
+    const characterName = decodeURIComponent(name);
+    const decodedWeaponType = decodeURIComponent(weaponType);
+
+    const docRef = db.collection('characters').doc(characterName);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    const data = doc.data();
+    const currentStats: BaseStats = data?.baseStats ?? {};
+    const weaponStats: WeaponStat[] = currentStats.weaponStats ?? [];
+
+    const filtered = weaponStats.filter((w) => w.weaponType !== decodedWeaponType);
+    if (filtered.length === weaponStats.length) {
+      return NextResponse.json({ error: 'Weapon stat not found' }, { status: 404 });
+    }
+
+    await docRef.update({ 'baseStats.weaponStats': filtered });
+
+    invalidateStatsCache();
+
+    return NextResponse.json({ success: true, message: '무기 스탯이 삭제되었습니다.' });
+  } catch (error) {
+    console.error('Weapon stat DELETE error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/characters/[name]/stats/weapons/route.ts
+++ b/src/app/api/admin/characters/[name]/stats/weapons/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/firebase-admin';
+import { verifyAdmin, invalidateStatsCache } from '@/lib/admin-utils';
+import type { WeaponStat, BaseStats } from '@/types/patch';
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ name: string }> }
+): Promise<NextResponse> {
+  try {
+    const authHeader = request.headers.get('Authorization');
+    const isAdmin = await verifyAdmin(authHeader);
+
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { name } = await params;
+    const characterName = decodeURIComponent(name);
+    const body = (await request.json()) as WeaponStat;
+
+    if (!body.weaponType?.trim()) {
+      return NextResponse.json({ error: '무기 타입을 입력하세요.' }, { status: 400 });
+    }
+
+    const docRef = db.collection('characters').doc(characterName);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+    }
+
+    const data = doc.data();
+    const currentStats: BaseStats = data?.baseStats ?? {};
+    const weaponStats: WeaponStat[] = currentStats.weaponStats ?? [];
+
+    const alreadyExists = weaponStats.some((w) => w.weaponType === body.weaponType);
+    if (alreadyExists) {
+      return NextResponse.json({ error: '이미 존재하는 무기 타입입니다.' }, { status: 409 });
+    }
+
+    const newWeaponStat: WeaponStat = {
+      weaponType: body.weaponType.trim(),
+      attackSpeedGrowth: body.attackSpeedGrowth ?? null,
+      basicAttackAmpGrowth: body.basicAttackAmpGrowth ?? null,
+      skillAmpGrowth: body.skillAmpGrowth ?? null,
+    };
+
+    weaponStats.push(newWeaponStat);
+
+    await docRef.update({ 'baseStats.weaponStats': weaponStats });
+
+    invalidateStatsCache();
+
+    return NextResponse.json({ success: true, message: '무기 스탯이 추가되었습니다.' });
+  } catch (error) {
+    console.error('Weapon stat POST error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/characters/route.ts
+++ b/src/app/api/admin/characters/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/firebase-admin';
+import { verifyAdmin, invalidateBalanceCache, invalidateStatsCache } from '@/lib/admin-utils';
+import type { BaseStats } from '@/types/patch';
+
+type CreateCharacterBody = {
+  name: string;
+  nameEn?: string;
+  baseStats: BaseStats;
+};
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    const authHeader = request.headers.get('Authorization');
+    const isAdmin = await verifyAdmin(authHeader);
+
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await request.json()) as CreateCharacterBody;
+    const { name, nameEn, baseStats } = body;
+
+    if (!name?.trim()) {
+      return NextResponse.json({ error: '이름을 입력하세요.' }, { status: 400 });
+    }
+
+    if (!baseStats.weaponStats || baseStats.weaponStats.length === 0) {
+      return NextResponse.json(
+        { error: '무기 역할군을 최소 1개 이상 입력하세요.' },
+        { status: 400 }
+      );
+    }
+
+    const docRef = db.collection('characters').doc(name.trim());
+    const existing = await docRef.get();
+
+    if (existing.exists) {
+      return NextResponse.json({ error: '이미 존재하는 실험체입니다.' }, { status: 409 });
+    }
+
+    await docRef.set({
+      name: name.trim(),
+      ...(nameEn ? { nameEn } : {}),
+      baseStats: {
+        ...baseStats,
+        crawledAt: new Date().toISOString(),
+      },
+      stats: {
+        totalPatches: 0,
+        buffCount: 0,
+        nerfCount: 0,
+        mixedCount: 0,
+        currentStreak: { type: null, count: 0 },
+        maxBuffStreak: 0,
+        maxNerfStreak: 0,
+      },
+      patchHistory: [],
+    });
+
+    invalidateBalanceCache();
+    invalidateStatsCache();
+
+    return NextResponse.json({ success: true, message: '실험체가 추가되었습니다.' });
+  } catch (error) {
+    console.error('Character create error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/admin/AddCharacterModal.tsx
+++ b/src/components/admin/AddCharacterModal.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+
+const WEAPON_TYPES = [
+  'VF의수',
+  '권총',
+  '글러브',
+  '기타',
+  '단검',
+  '도끼',
+  '돌격 소총',
+  '레이피어',
+  '망치',
+  '방망이',
+  '석궁',
+  '쌍검',
+  '쌍절곤',
+  '아르카나',
+  '암기',
+  '양손검',
+  '저격총',
+  '창',
+  '채찍',
+  '카메라',
+  '톤파',
+  '투척',
+  '활',
+] as const;
+
+type WeaponStatInput = {
+  weaponType: string;
+  attackSpeedGrowth: string;
+  basicAttackAmpGrowth: string;
+  skillAmpGrowth: string;
+};
+
+type AddCharacterModalProps = {
+  onClose: () => void;
+  onSuccess: () => void;
+};
+
+const emptyWeapon = (): WeaponStatInput => ({
+  weaponType: '',
+  attackSpeedGrowth: '',
+  basicAttackAmpGrowth: '',
+  skillAmpGrowth: '',
+});
+
+const parseNum = (v: string): number | null => {
+  const n = parseFloat(v);
+  return isNaN(n) ? null : n;
+};
+
+export function AddCharacterModal({
+  onClose,
+  onSuccess,
+}: AddCharacterModalProps): React.JSX.Element {
+  const { user } = useAuth();
+  const [name, setName] = useState('');
+  const [nameEn, setNameEn] = useState('');
+  const [hpBase, setHpBase] = useState('');
+  const [hpGrowth, setHpGrowth] = useState('');
+  const [hpRegenBase, setHpRegenBase] = useState('');
+  const [hpRegenGrowth, setHpRegenGrowth] = useState('');
+  const [defenseBase, setDefenseBase] = useState('');
+  const [defenseGrowth, setDefenseGrowth] = useState('');
+  const [attackBase, setAttackBase] = useState('');
+  const [attackGrowth, setAttackGrowth] = useState('');
+  const [attackSpeedBase, setAttackSpeedBase] = useState('');
+  const [moveSpeed, setMoveSpeed] = useState('');
+  const [weapons, setWeapons] = useState<WeaponStatInput[]>([emptyWeapon()]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateWeapon = (idx: number, field: keyof WeaponStatInput, value: string): void => {
+    setWeapons((prev) => prev.map((w, i) => (i === idx ? { ...w, [field]: value } : w)));
+  };
+
+  const addWeapon = (): void => setWeapons((prev) => [...prev, emptyWeapon()]);
+
+  const removeWeapon = (idx: number): void => {
+    if (weapons.length === 1) return;
+    setWeapons((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!name.trim()) {
+      setError('실험체 이름을 입력하세요.');
+      return;
+    }
+    const validWeapons = weapons.filter((w) => w.weaponType.trim());
+    if (validWeapons.length === 0) {
+      setError('무기 역할군을 최소 1개 입력하세요.');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      setError(null);
+
+      const token = await user?.getIdToken();
+      const res = await fetch('/api/admin/characters', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          name: name.trim(),
+          nameEn: nameEn.trim() || undefined,
+          baseStats: {
+            hpBase: parseNum(hpBase),
+            hpGrowth: parseNum(hpGrowth),
+            hpRegenBase: parseNum(hpRegenBase),
+            hpRegenGrowth: parseNum(hpRegenGrowth),
+            defenseBase: parseNum(defenseBase),
+            defenseGrowth: parseNum(defenseGrowth),
+            attackBase: parseNum(attackBase),
+            attackGrowth: parseNum(attackGrowth),
+            attackSpeedBase: parseNum(attackSpeedBase),
+            moveSpeed: parseNum(moveSpeed),
+            weaponStats: validWeapons.map((w) => ({
+              weaponType: w.weaponType,
+              attackSpeedGrowth: parseNum(w.attackSpeedGrowth),
+              basicAttackAmpGrowth: parseNum(w.basicAttackAmpGrowth),
+              skillAmpGrowth: parseNum(w.skillAmpGrowth),
+            })),
+          },
+        }),
+      });
+
+      const data = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        setError(data.error ?? '저장 실패');
+        return;
+      }
+
+      onSuccess();
+    } catch {
+      setError('저장 중 오류가 발생했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-start justify-center z-50 p-4 overflow-y-auto">
+      <div className="bg-er-surface border border-er-border rounded-xl p-6 w-full max-w-2xl my-8">
+        <h2 className="text-xl font-bold text-white mb-6">새 실험체 추가</h2>
+
+        {error && (
+          <div className="mb-4 p-3 bg-rose-500/10 border border-rose-500/30 rounded-lg text-rose-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        {/* 기본 정보 */}
+        <section className="mb-6">
+          <h3 className="text-sm font-semibold text-gray-300 mb-3">기본 정보</h3>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">이름 (한글) *</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="예: 재키"
+                className="w-full px-3 py-2 bg-er-surface-dark border border-er-border rounded-lg text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">이름 (영문)</label>
+              <input
+                type="text"
+                value={nameEn}
+                onChange={(e) => setNameEn(e.target.value)}
+                placeholder="예: Jackie"
+                className="w-full px-3 py-2 bg-er-surface-dark border border-er-border rounded-lg text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* 기본 스탯 */}
+        <section className="mb-6">
+          <h3 className="text-sm font-semibold text-gray-300 mb-3">기본 스탯 (Lv.1)</h3>
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              { label: '체력 기본', value: hpBase, setter: setHpBase, placeholder: '850' },
+              { label: '체력 성장', value: hpGrowth, setter: setHpGrowth, placeholder: '40' },
+              {
+                label: '체력 재생 기본',
+                value: hpRegenBase,
+                setter: setHpRegenBase,
+                placeholder: '2.5',
+              },
+              {
+                label: '체력 재생 성장',
+                value: hpRegenGrowth,
+                setter: setHpRegenGrowth,
+                placeholder: '0.1',
+              },
+              {
+                label: '방어력 기본',
+                value: defenseBase,
+                setter: setDefenseBase,
+                placeholder: '20',
+              },
+              {
+                label: '방어력 성장',
+                value: defenseGrowth,
+                setter: setDefenseGrowth,
+                placeholder: '3',
+              },
+              { label: '공격력 기본', value: attackBase, setter: setAttackBase, placeholder: '55' },
+              {
+                label: '공격력 성장',
+                value: attackGrowth,
+                setter: setAttackGrowth,
+                placeholder: '3',
+              },
+              {
+                label: '공격속도 기본',
+                value: attackSpeedBase,
+                setter: setAttackSpeedBase,
+                placeholder: '1.00',
+              },
+              { label: '이동속도', value: moveSpeed, setter: setMoveSpeed, placeholder: '350' },
+            ].map(({ label, value, setter, placeholder }) => (
+              <div key={label}>
+                <label className="block text-xs text-gray-400 mb-1">{label}</label>
+                <input
+                  type="number"
+                  value={value}
+                  onChange={(e) => setter(e.target.value)}
+                  placeholder={placeholder}
+                  step="any"
+                  className="w-full px-3 py-2 bg-er-surface-dark border border-er-border rounded-lg text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 무기 스탯 */}
+        <section className="mb-6">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-semibold text-gray-300">무기 역할군 *</h3>
+            <button
+              type="button"
+              onClick={addWeapon}
+              className="text-xs text-violet-400 hover:text-violet-300 transition-colors"
+            >
+              + 추가
+            </button>
+          </div>
+          <div className="space-y-3">
+            {weapons.map((weapon, idx) => (
+              <div key={idx} className="p-3 bg-er-surface-dark border border-er-border rounded-lg">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-xs text-gray-400">무기 {idx + 1}</span>
+                  {weapons.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removeWeapon(idx)}
+                      className="text-xs text-rose-400 hover:text-rose-300 transition-colors"
+                    >
+                      삭제
+                    </button>
+                  )}
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="col-span-2">
+                    <label className="block text-xs text-gray-400 mb-1">무기 타입 *</label>
+                    <select
+                      value={weapon.weaponType}
+                      onChange={(e) => updateWeapon(idx, 'weaponType', e.target.value)}
+                      className="w-full px-3 py-2 bg-er-surface border border-er-border rounded-lg text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+                    >
+                      <option value="">선택...</option>
+                      {WEAPON_TYPES.map((wt) => (
+                        <option key={wt} value={wt}>
+                          {wt}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {[
+                    {
+                      label: '공속 성장 (%)',
+                      field: 'attackSpeedGrowth' as const,
+                      placeholder: '3',
+                    },
+                    {
+                      label: '기공 증폭 성장 (%)',
+                      field: 'basicAttackAmpGrowth' as const,
+                      placeholder: '2',
+                    },
+                    {
+                      label: '스킬 증폭 성장 (%)',
+                      field: 'skillAmpGrowth' as const,
+                      placeholder: '4.4',
+                    },
+                  ].map(({ label, field, placeholder }) => (
+                    <div key={field}>
+                      <label className="block text-xs text-gray-400 mb-1">{label}</label>
+                      <input
+                        type="number"
+                        value={weapon[field]}
+                        onChange={(e) => updateWeapon(idx, field, e.target.value)}
+                        placeholder={placeholder}
+                        step="any"
+                        className="w-full px-3 py-2 bg-er-surface border border-er-border rounded-lg text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-2 text-gray-400 hover:text-white transition-colors"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={saving}
+            className="px-4 py-2 bg-violet-600 hover:bg-violet-700 disabled:bg-violet-800 text-white rounded-lg transition-colors"
+          >
+            {saving ? '저장 중...' : '추가'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -43,6 +43,12 @@ export function AdminHeader(): React.JSX.Element {
               이미지 관리
             </Link>
             <Link
+              href="/admin/stats"
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-white/5 rounded transition-colors"
+            >
+              스탯 관리
+            </Link>
+            <Link
               href="/admin/bugs"
               className="px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-white/5 rounded transition-colors"
             >

--- a/src/components/admin/AdminStatsList.tsx
+++ b/src/components/admin/AdminStatsList.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import Link from 'next/link';
+import { AddCharacterModal } from '@/components/admin/AddCharacterModal';
+import type { CharacterStatEntry } from '@/lib/stats-data';
+
+type AdminStatsListProps = {
+  entries: CharacterStatEntry[];
+  allCharacterNames: string[];
+};
+
+export function AdminStatsList({
+  entries,
+  allCharacterNames,
+}: AdminStatsListProps): React.JSX.Element {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showModal, setShowModal] = useState(false);
+
+  const statsMap = useMemo(() => new Map(entries.map((e) => [e.name, e])), [entries]);
+
+  const filteredNames = useMemo(() => {
+    const q = searchQuery.toLowerCase().trim();
+    if (!q) return allCharacterNames;
+    return allCharacterNames.filter((n) => n.toLowerCase().includes(q));
+  }, [allCharacterNames, searchQuery]);
+
+  const handleSuccess = (): void => {
+    setShowModal(false);
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-3 mb-6">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="실험체 검색..."
+          className="flex-1 max-w-md px-4 py-2 bg-er-surface border border-er-border rounded-lg text-white placeholder-gray-500 focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+        />
+        <button
+          onClick={() => setShowModal(true)}
+          className="px-4 py-2 bg-violet-600 hover:bg-violet-700 text-white rounded-lg text-sm transition-colors whitespace-nowrap"
+        >
+          + 실험체 추가
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+        {filteredNames.map((name) => {
+          const entry = statsMap.get(name);
+          const hasStats = !!entry;
+
+          return (
+            <Link
+              key={name}
+              href={`/admin/stats/${encodeURIComponent(name)}`}
+              className="block p-4 bg-er-surface border border-er-border rounded-lg hover:border-violet-500/50 hover:bg-er-surface-light transition-all"
+            >
+              <div className="text-white font-medium mb-1 truncate">{name}</div>
+              {hasStats ? (
+                <div className="text-xs text-gray-400">
+                  <div className="text-emerald-400/80 mb-0.5">스탯 있음</div>
+                  <div>{entry.baseStats.weaponStats.length}개 무기</div>
+                </div>
+              ) : (
+                <div className="text-xs text-amber-400/80">스탯 없음</div>
+              )}
+            </Link>
+          );
+        })}
+      </div>
+
+      {filteredNames.length === 0 && (
+        <div className="text-center py-12 text-gray-400">검색 결과가 없습니다.</div>
+      )}
+
+      {showModal && (
+        <AddCharacterModal onClose={() => setShowModal(false)} onSuccess={handleSuccess} />
+      )}
+    </>
+  );
+}

--- a/src/components/admin/CharacterStatEditor.tsx
+++ b/src/components/admin/CharacterStatEditor.tsx
@@ -1,0 +1,515 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { DeleteConfirmDialog } from '@/components/admin/DeleteConfirmDialog';
+import type { BaseStats, WeaponStat } from '@/types/patch';
+
+const WEAPON_TYPES = [
+  'VF의수',
+  '권총',
+  '글러브',
+  '기타',
+  '단검',
+  '도끼',
+  '돌격 소총',
+  '레이피어',
+  '망치',
+  '방망이',
+  '석궁',
+  '쌍검',
+  '쌍절곤',
+  '아르카나',
+  '암기',
+  '양손검',
+  '저격총',
+  '창',
+  '채찍',
+  '카메라',
+  '톤파',
+  '투척',
+  '활',
+] as const;
+
+type CharacterStatEditorProps = {
+  characterName: string;
+  initialStats: BaseStats | null;
+};
+
+type BaseStatField = {
+  key: keyof Omit<BaseStats, 'weaponStats' | 'crawledAt'>;
+  label: string;
+  placeholder: string;
+  step?: string;
+};
+
+const BASE_STAT_FIELDS: BaseStatField[] = [
+  { key: 'hpBase', label: '체력 기본', placeholder: '850' },
+  { key: 'hpGrowth', label: '체력 성장', placeholder: '40' },
+  { key: 'hpRegenBase', label: '체력 재생 기본', placeholder: '2.5', step: '0.01' },
+  { key: 'hpRegenGrowth', label: '체력 재생 성장', placeholder: '0.1', step: '0.01' },
+  { key: 'defenseBase', label: '방어력 기본', placeholder: '20' },
+  { key: 'defenseGrowth', label: '방어력 성장', placeholder: '3' },
+  { key: 'attackBase', label: '공격력 기본', placeholder: '55' },
+  { key: 'attackGrowth', label: '공격력 성장', placeholder: '3' },
+  { key: 'attackSpeedBase', label: '공격속도 기본', placeholder: '1.00', step: '0.01' },
+  { key: 'moveSpeed', label: '이동속도', placeholder: '350' },
+];
+
+const parseNum = (v: string): number | null => {
+  if (v === '' || v === null) return null;
+  const n = parseFloat(v);
+  return isNaN(n) ? null : n;
+};
+
+const formatVal = (v: number | null | undefined): string =>
+  v === null || v === undefined ? '' : String(v);
+
+type WeaponStatEditState = {
+  attackSpeedGrowth: string;
+  basicAttackAmpGrowth: string;
+  skillAmpGrowth: string;
+};
+
+export function CharacterStatEditor({
+  characterName,
+  initialStats,
+}: CharacterStatEditorProps): React.JSX.Element {
+  const { user } = useAuth();
+
+  const initBase = (): Record<string, string> => {
+    const result: Record<string, string> = {};
+    for (const f of BASE_STAT_FIELDS) {
+      result[f.key] = formatVal(initialStats?.[f.key] as number | null);
+    }
+    return result;
+  };
+
+  const [baseValues, setBaseValues] = useState<Record<string, string>>(initBase);
+  const [baseSaving, setBaseSaving] = useState(false);
+  const [baseError, setBaseError] = useState<string | null>(null);
+  const [baseSuccess, setBaseSuccess] = useState(false);
+
+  const [weaponStats, setWeaponStats] = useState<WeaponStat[]>(initialStats?.weaponStats ?? []);
+  const [editingWeapon, setEditingWeapon] = useState<string | null>(null);
+  const [weaponEditValues, setWeaponEditValues] = useState<WeaponStatEditState>({
+    attackSpeedGrowth: '',
+    basicAttackAmpGrowth: '',
+    skillAmpGrowth: '',
+  });
+  const [weaponSaving, setWeaponSaving] = useState(false);
+  const [weaponError, setWeaponError] = useState<string | null>(null);
+
+  const [deletingWeapon, setDeletingWeapon] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const [newWeaponType, setNewWeaponType] = useState('');
+  const [newWeaponValues, setNewWeaponValues] = useState<WeaponStatEditState>({
+    attackSpeedGrowth: '',
+    basicAttackAmpGrowth: '',
+    skillAmpGrowth: '',
+  });
+  const [addingWeapon, setAddingWeapon] = useState(false);
+  const [addWeaponError, setAddWeaponError] = useState<string | null>(null);
+  const [showAddWeapon, setShowAddWeapon] = useState(false);
+
+  const getToken = async (): Promise<string | undefined> => user?.getIdToken();
+
+  const handleBaseSave = async (): Promise<void> => {
+    try {
+      setBaseSaving(true);
+      setBaseError(null);
+      setBaseSuccess(false);
+
+      const token = await getToken();
+      const body: Record<string, number | null> = {};
+      for (const f of BASE_STAT_FIELDS) {
+        body[f.key] = parseNum(baseValues[f.key]);
+      }
+
+      const res = await fetch(`/api/admin/characters/${encodeURIComponent(characterName)}/stats`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(body),
+      });
+
+      const data = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        setBaseError(data.error ?? '저장 실패');
+        return;
+      }
+      setBaseSuccess(true);
+      setTimeout(() => setBaseSuccess(false), 3000);
+    } catch {
+      setBaseError('저장 중 오류가 발생했습니다.');
+    } finally {
+      setBaseSaving(false);
+    }
+  };
+
+  const startEditWeapon = (ws: WeaponStat): void => {
+    setEditingWeapon(ws.weaponType);
+    setWeaponEditValues({
+      attackSpeedGrowth: formatVal(ws.attackSpeedGrowth),
+      basicAttackAmpGrowth: formatVal(ws.basicAttackAmpGrowth),
+      skillAmpGrowth: formatVal(ws.skillAmpGrowth),
+    });
+    setWeaponError(null);
+  };
+
+  const cancelEditWeapon = (): void => {
+    setEditingWeapon(null);
+    setWeaponError(null);
+  };
+
+  const handleWeaponSave = async (weaponType: string): Promise<void> => {
+    try {
+      setWeaponSaving(true);
+      setWeaponError(null);
+
+      const token = await getToken();
+      const res = await fetch(
+        `/api/admin/characters/${encodeURIComponent(characterName)}/stats/weapons/${encodeURIComponent(weaponType)}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            attackSpeedGrowth: parseNum(weaponEditValues.attackSpeedGrowth),
+            basicAttackAmpGrowth: parseNum(weaponEditValues.basicAttackAmpGrowth),
+            skillAmpGrowth: parseNum(weaponEditValues.skillAmpGrowth),
+          }),
+        }
+      );
+
+      const data = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        setWeaponError(data.error ?? '저장 실패');
+        return;
+      }
+
+      setWeaponStats((prev) =>
+        prev.map((w) =>
+          w.weaponType === weaponType
+            ? {
+                ...w,
+                attackSpeedGrowth: parseNum(weaponEditValues.attackSpeedGrowth),
+                basicAttackAmpGrowth: parseNum(weaponEditValues.basicAttackAmpGrowth),
+                skillAmpGrowth: parseNum(weaponEditValues.skillAmpGrowth),
+              }
+            : w
+        )
+      );
+      setEditingWeapon(null);
+    } catch {
+      setWeaponError('저장 중 오류가 발생했습니다.');
+    } finally {
+      setWeaponSaving(false);
+    }
+  };
+
+  const handleWeaponDelete = async (): Promise<void> => {
+    if (!deletingWeapon) return;
+    try {
+      setIsDeleting(true);
+
+      const token = await getToken();
+      const res = await fetch(
+        `/api/admin/characters/${encodeURIComponent(characterName)}/stats/weapons/${encodeURIComponent(deletingWeapon)}`,
+        {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+
+      if (res.ok) {
+        setWeaponStats((prev) => prev.filter((w) => w.weaponType !== deletingWeapon));
+      }
+      setDeletingWeapon(null);
+    } catch {
+      /* empty */
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleAddWeapon = async (): Promise<void> => {
+    if (!newWeaponType) {
+      setAddWeaponError('무기 타입을 선택하세요.');
+      return;
+    }
+    try {
+      setAddingWeapon(true);
+      setAddWeaponError(null);
+
+      const token = await getToken();
+      const res = await fetch(
+        `/api/admin/characters/${encodeURIComponent(characterName)}/stats/weapons`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            weaponType: newWeaponType,
+            attackSpeedGrowth: parseNum(newWeaponValues.attackSpeedGrowth),
+            basicAttackAmpGrowth: parseNum(newWeaponValues.basicAttackAmpGrowth),
+            skillAmpGrowth: parseNum(newWeaponValues.skillAmpGrowth),
+          }),
+        }
+      );
+
+      const data = (await res.json()) as { error?: string };
+      if (!res.ok) {
+        setAddWeaponError(data.error ?? '저장 실패');
+        return;
+      }
+
+      setWeaponStats((prev) => [
+        ...prev,
+        {
+          weaponType: newWeaponType,
+          attackSpeedGrowth: parseNum(newWeaponValues.attackSpeedGrowth),
+          basicAttackAmpGrowth: parseNum(newWeaponValues.basicAttackAmpGrowth),
+          skillAmpGrowth: parseNum(newWeaponValues.skillAmpGrowth),
+        },
+      ]);
+      setNewWeaponType('');
+      setNewWeaponValues({ attackSpeedGrowth: '', basicAttackAmpGrowth: '', skillAmpGrowth: '' });
+      setShowAddWeapon(false);
+    } catch {
+      setAddWeaponError('저장 중 오류가 발생했습니다.');
+    } finally {
+      setAddingWeapon(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* 기본 스탯 섹션 */}
+      <section className="bg-er-surface border border-er-border rounded-xl p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-white">기본 스탯</h2>
+          {baseSuccess && <span className="text-sm text-emerald-400">저장 완료</span>}
+        </div>
+
+        {baseError && (
+          <div className="mb-4 p-3 bg-rose-500/10 border border-rose-500/30 rounded-lg text-rose-400 text-sm">
+            {baseError}
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-6">
+          {BASE_STAT_FIELDS.map((f) => (
+            <div key={f.key}>
+              <label className="block text-xs text-gray-400 mb-1">{f.label}</label>
+              <input
+                type="number"
+                value={baseValues[f.key]}
+                onChange={(e) => setBaseValues((prev) => ({ ...prev, [f.key]: e.target.value }))}
+                placeholder={f.placeholder}
+                step={f.step ?? '1'}
+                className="w-full px-3 py-2 bg-er-surface-dark border border-er-border rounded-lg text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            onClick={handleBaseSave}
+            disabled={baseSaving}
+            className="px-4 py-2 bg-violet-600 hover:bg-violet-700 disabled:bg-violet-800 text-white rounded-lg text-sm transition-colors"
+          >
+            {baseSaving ? '저장 중...' : '기본 스탯 저장'}
+          </button>
+        </div>
+      </section>
+
+      {/* 무기 스탯 섹션 */}
+      <section className="bg-er-surface border border-er-border rounded-xl p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-white">무기 역할군 스탯</h2>
+          <button
+            onClick={() => {
+              setShowAddWeapon((v) => !v);
+              setAddWeaponError(null);
+            }}
+            className="text-sm text-violet-400 hover:text-violet-300 transition-colors"
+          >
+            {showAddWeapon ? '닫기' : '+ 추가'}
+          </button>
+        </div>
+
+        {weaponError && (
+          <div className="mb-4 p-3 bg-rose-500/10 border border-rose-500/30 rounded-lg text-rose-400 text-sm">
+            {weaponError}
+          </div>
+        )}
+
+        {/* 무기 추가 폼 */}
+        {showAddWeapon && (
+          <div className="mb-4 p-4 bg-er-surface-dark border border-violet-500/30 rounded-lg">
+            <h3 className="text-sm font-medium text-gray-300 mb-3">무기 추가</h3>
+            {addWeaponError && (
+              <div className="mb-3 p-2 bg-rose-500/10 border border-rose-500/30 rounded text-rose-400 text-xs">
+                {addWeaponError}
+              </div>
+            )}
+            <div className="grid grid-cols-2 gap-3 mb-3">
+              <div className="col-span-2">
+                <label className="block text-xs text-gray-400 mb-1">무기 타입 *</label>
+                <select
+                  value={newWeaponType}
+                  onChange={(e) => setNewWeaponType(e.target.value)}
+                  className="w-full px-3 py-2 bg-er-surface border border-er-border rounded-lg text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+                >
+                  <option value="">선택...</option>
+                  {WEAPON_TYPES.filter((wt) => !weaponStats.some((w) => w.weaponType === wt)).map(
+                    (wt) => (
+                      <option key={wt} value={wt}>
+                        {wt}
+                      </option>
+                    )
+                  )}
+                </select>
+              </div>
+              {(
+                [
+                  { field: 'attackSpeedGrowth', label: '공속 성장 (%)' },
+                  { field: 'basicAttackAmpGrowth', label: '기공 증폭 성장 (%)' },
+                  { field: 'skillAmpGrowth', label: '스킬 증폭 성장 (%)' },
+                ] as const
+              ).map(({ field, label }) => (
+                <div key={field}>
+                  <label className="block text-xs text-gray-400 mb-1">{label}</label>
+                  <input
+                    type="number"
+                    value={newWeaponValues[field]}
+                    onChange={(e) =>
+                      setNewWeaponValues((prev) => ({ ...prev, [field]: e.target.value }))
+                    }
+                    step="any"
+                    className="w-full px-3 py-2 bg-er-surface border border-er-border rounded-lg text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setShowAddWeapon(false);
+                  setAddWeaponError(null);
+                }}
+                className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleAddWeapon}
+                disabled={addingWeapon}
+                className="px-3 py-1.5 bg-violet-600 hover:bg-violet-700 disabled:bg-violet-800 text-white rounded text-sm transition-colors"
+              >
+                {addingWeapon ? '추가 중...' : '추가'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {weaponStats.length === 0 ? (
+          <p className="text-gray-500 text-sm py-4 text-center">무기 스탯 데이터가 없습니다.</p>
+        ) : (
+          <div className="space-y-3">
+            {weaponStats.map((ws) => (
+              <div
+                key={ws.weaponType}
+                className="p-4 bg-er-surface-dark border border-er-border rounded-lg"
+              >
+                {editingWeapon === ws.weaponType ? (
+                  <>
+                    <div className="flex items-center justify-between mb-3">
+                      <span className="text-sm font-medium text-white">{ws.weaponType}</span>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2 mb-3">
+                      {(
+                        [
+                          { field: 'attackSpeedGrowth', label: '공속 성장 (%)' },
+                          { field: 'basicAttackAmpGrowth', label: '기공 증폭 (%)' },
+                          { field: 'skillAmpGrowth', label: '스킬 증폭 (%)' },
+                        ] as const
+                      ).map(({ field, label }) => (
+                        <div key={field}>
+                          <label className="block text-xs text-gray-400 mb-1">{label}</label>
+                          <input
+                            type="number"
+                            value={weaponEditValues[field]}
+                            onChange={(e) =>
+                              setWeaponEditValues((prev) => ({
+                                ...prev,
+                                [field]: e.target.value,
+                              }))
+                            }
+                            step="any"
+                            className="w-full px-2 py-1.5 bg-er-surface border border-er-border rounded text-white text-sm focus:outline-hidden focus:ring-2 focus:ring-violet-500"
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="flex justify-end gap-2">
+                      <button
+                        onClick={cancelEditWeapon}
+                        disabled={weaponSaving}
+                        className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+                      >
+                        취소
+                      </button>
+                      <button
+                        onClick={() => handleWeaponSave(ws.weaponType)}
+                        disabled={weaponSaving}
+                        className="px-3 py-1.5 bg-violet-600 hover:bg-violet-700 disabled:bg-violet-800 text-white rounded text-sm transition-colors"
+                      >
+                        {weaponSaving ? '저장 중...' : '저장'}
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <span className="text-sm font-medium text-white">{ws.weaponType}</span>
+                      <div className="flex gap-4 mt-1 text-xs text-gray-400">
+                        <span>공속 성장: {ws.attackSpeedGrowth ?? '-'}%</span>
+                        <span>기공 증폭: {ws.basicAttackAmpGrowth ?? '-'}%</span>
+                        <span>스킬 증폭: {ws.skillAmpGrowth ?? '-'}%</span>
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => startEditWeapon(ws)}
+                        className="px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-white/5 rounded transition-colors"
+                      >
+                        수정
+                      </button>
+                      <button
+                        onClick={() => setDeletingWeapon(ws.weaponType)}
+                        className="px-3 py-1.5 text-sm text-rose-400 hover:text-rose-300 hover:bg-rose-500/10 rounded transition-colors"
+                      >
+                        삭제
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {deletingWeapon && (
+        <DeleteConfirmDialog
+          title="무기 스탯 삭제"
+          message={`"${deletingWeapon}" 무기 스탯을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.`}
+          isDeleting={isDeleting}
+          onConfirm={handleWeaponDelete}
+          onCancel={() => setDeletingWeapon(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/lib/admin-utils.ts
+++ b/src/lib/admin-utils.ts
@@ -80,3 +80,13 @@ export function invalidateCharacterCache(characterName: string): void {
   revalidatePath(`/character/${encodedName}`, 'page');
   revalidatePath(`/admin/character/${encodedName}`, 'page');
 }
+
+/**
+ * 실험체 스탯 관련 캐시를 무효화합니다.
+ */
+export function invalidateStatsCache(): void {
+  revalidateTag('character-stats', 'max');
+  revalidatePath('/stats', 'page');
+  revalidatePath('/stats/[name]', 'page');
+  revalidatePath('/admin/stats', 'page');
+}


### PR DESCRIPTION


## 관련 이슈

closes #99 

## 변경 사항

- /admin/stats: 실험체 목록 및 스탯 현황 확인
- /admin/stats/[name]: 기본 스탯 수정, 무기 스탯 추가/수정/삭제 (삭제 시 경고)
- POST /api/admin/characters: 새 실험체 추가 (무기 역할군 최소 1개)
- GET/PUT /api/admin/characters/[name]/stats: 기본 스탯 조회/수정
- POST /api/admin/characters/[name]/stats/weapons: 무기 스탯 추가
- PUT/DELETE /api/admin/characters/[name]/stats/weapons/[weaponType]: 무기 스탯 수정/삭제
- AdminHeader에 스탯 관리 메뉴 추가
- admin-utils에 invalidateStatsCache() 추가

## 변경 유형

- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
