### PR TITLE
[perf] Firebase characters 컬렉션 중복 쿼리 제거

### DIFF
--- a/docs/work-logs/2026-05-01-Firebase읽기최적화.md
+++ b/docs/work-logs/2026-05-01-Firebase읽기최적화.md
@@ -1,0 +1,127 @@
+# Firebase 빌드 시 읽기 과다 최적화
+
+## 개요
+
+- **시작일**: 2026-05-01
+- **완료일**: 2026-05-02
+- **상태**: 완료
+- **관련 브랜치**: feature/112
+
+## 목표
+
+- [x] `loadAllStats`가 별도 Firestore 쿼리 없이 `loadBalanceData()` 데이터에서 파생되도록 변경
+- [x] `loadBugRankingData`가 별도 Firestore 쿼리 없이 `loadBalanceData()` 데이터에서 파생되도록 변경
+- [x] 빌드 1회당 `characters` 컬렉션 읽기를 ~3000 → ~1000 이하로 감소
+
+## 문제 분석
+
+### 현재 상황
+
+빌드 1회당 `characters` 컬렉션을 약 **34회 실행 × 87 docs = ~3000 reads** 소모.
+
+Firebase 콘솔 데이터:
+
+- `COLLECTION /characters`: 총 49,416 읽기 작업 / 568 실행 (빌드당 ~34회)
+- `COLLECTION /patchNotes ORDER_BY id`: 총 2,432 / 8회 실행
+
+### 원인
+
+`characters` 컬렉션을 **3개의 함수가 독립적으로** 전체 스캔:
+
+```typescript
+// patch-data.ts
+loadBalanceData()    → db.collection('characters').get()  [캐시키: 'balance-data']
+loadBugRankingData() → db.collection('characters').get()  [캐시키: 'bug-ranking-data']
+
+// stats-data.ts
+loadAllStats()       → db.collection('characters').get()  [캐시키: 'character-stats']
+```
+
+Next.js 병렬 빌드 workers가 disk 캐시가 채워지기 전에 동시에 Firestore를 조회하는
+**thundering herd** 현상으로 34회까지 증폭됨.
+
+## 해결 방향
+
+### 방법 1 (즉각 효과): 중복 쿼리 제거
+
+`loadAllStats`와 `loadBugRankingData`가 직접 Firestore를 읽지 않고
+`loadBalanceData()` 반환 데이터에서 파생하도록 변경.
+
+**변경 대상 파일:**
+
+- `src/lib/stats-data.ts` - `fetchAllStats` 함수
+- `src/lib/patch-data.ts` - `fetchBugRankingData` 함수
+
+**변경 방법:**
+
+```typescript
+// stats-data.ts 변경 예시
+// Before: Firestore 직접 조회
+const fetchAllStats = async (): Promise<CharacterStatEntry[]> => {
+  const snapshot = await db.collection('characters').get();
+  // ...
+};
+
+// After: loadBalanceData에서 파생
+import { loadBalanceData } from './patch-data';
+
+const fetchAllStats = async (): Promise<CharacterStatEntry[]> => {
+  const data = await loadBalanceData();
+  return Object.values(data.characters)
+    .filter((char) => char.baseStats)
+    .map((char) => ({ name: char.name, baseStats: char.baseStats }))
+    .sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+};
+```
+
+```typescript
+// patch-data.ts 변경 예시
+// Before: Firestore 직접 조회
+const fetchBugRankingData = async (): Promise<CharacterBugSummary[]> => {
+  const snapshot = await db.collection('characters').get();
+  // ...
+};
+
+// After: loadBalanceData에서 파생
+const fetchBugRankingData = async (): Promise<CharacterBugSummary[]> => {
+  const data = await loadBalanceData();
+  const today = new Date().toISOString().slice(0, 10);
+  const results: CharacterBugSummary[] = [];
+
+  for (const char of Object.values(data.characters)) {
+    const totalBugCount = char.totalBugCount ?? 0;
+    const bugPatchIds = char.bugPatchIds ?? [];
+    if (totalBugCount === 0) continue;
+    // ... 나머지 계산 로직 동일
+  }
+
+  return results.sort((a, b) => b.bugsPerMonth - a.bugsPerMonth);
+};
+```
+
+**예상 효과:**
+
+- characters 쿼리 타입: 3종 → 1종
+- thundering herd 범위 축소: ~34회 → ~11-12회
+- 읽기 감소: ~3000 → ~1000 reads/빌드
+
+### 방법 2 (완전 해결): 빌드 전 JSON 사전 생성
+
+빌드 시 Firestore를 아예 읽지 않도록 `prebuild` 스크립트로 데이터를 JSON 파일에 저장,
+각 페이지는 파일시스템에서 읽는 방식. 큰 아키텍처 변경이므로 방법 1 먼저 적용 후 검토.
+
+## 완료된 작업 (2026-05-02)
+
+- [x] `Character` 타입에 `baseStats?`, `totalBugCount?`, `bugPatchIds?`, `releaseDate?` 필드 추가 (`src/types/patch.ts`)
+- [x] `src/lib/stats-data.ts`의 `fetchAllStats`를 `loadBalanceData()` 파생으로 교체 (db import 제거)
+- [x] `src/lib/patch-data.ts`의 `fetchBugRankingData`를 `loadBalanceData()` 파생으로 교체
+- [x] `npm run build` 성공 확인 (198 페이지, 타입 에러 없음)
+
+## 관련 파일
+
+- `src/lib/patch-data.ts` - `fetchBalanceData`, `fetchBugRankingData`, `loadBalanceData`, `loadBugRankingData`
+- `src/lib/stats-data.ts` - `fetchAllStats`, `loadAllStats`
+- `src/types/patch.ts` - `Character` 타입 (baseStats, bugPatchIds 필드 존재 여부)
+- `src/app/character/[name]/page.tsx` - `generateStaticParams`, `generateMetadata`
+- `src/app/stats/[name]/page.tsx` - `generateStaticParams`
+- `src/app/bugs/page.tsx` - `loadBugRankingData` 사용처

--- a/src/lib/patch-data.ts
+++ b/src/lib/patch-data.ts
@@ -204,30 +204,29 @@ function daysBetween(startIso: string, endIso: string): number {
 }
 
 const fetchBugRankingData = async (): Promise<CharacterBugSummary[]> => {
-  const snapshot = await db.collection('characters').get();
+  const balanceData = await loadBalanceData();
   const results: CharacterBugSummary[] = [];
   const today = new Date().toISOString().slice(0, 10);
 
-  snapshot.forEach((doc) => {
-    const data = doc.data();
-    const totalBugCount = (data.totalBugCount as number | undefined) ?? 0;
-    const bugPatchIds = (data.bugPatchIds as number[] | undefined) ?? [];
-    if (totalBugCount === 0) return;
+  for (const char of Object.values(balanceData.characters)) {
+    const totalBugCount = char.totalBugCount ?? 0;
+    const bugPatchIds = char.bugPatchIds ?? [];
+    if (totalBugCount === 0) continue;
 
-    const releaseDate = (data.releaseDate as string | undefined) ?? BUG_DATA_START;
+    const releaseDate = char.releaseDate ?? BUG_DATA_START;
     const effectiveStartDate = releaseDate > BUG_DATA_START ? releaseDate : BUG_DATA_START;
     const days = daysBetween(effectiveStartDate, today);
     const bugsPerMonth = totalBugCount / (days / 30);
 
     results.push({
-      name: data.name as string,
+      name: char.name,
       totalBugCount,
       bugPatchCount: bugPatchIds.length,
       bugsPerMonth,
       releaseDate,
       effectiveStartDate,
     });
-  });
+  }
 
   return results.sort((a, b) => b.bugsPerMonth - a.bugsPerMonth);
 };

--- a/src/lib/stats-data.ts
+++ b/src/lib/stats-data.ts
@@ -1,5 +1,5 @@
 import { unstable_cache } from 'next/cache';
-import { db } from './firebase-admin';
+import { loadBalanceData } from './patch-data';
 import type { BaseStats, WeaponStat } from '@/types/patch';
 
 export type CharacterStatEntry = {
@@ -345,20 +345,11 @@ export const getRankings = (
 };
 
 const fetchAllStats = async (): Promise<CharacterStatEntry[]> => {
-  const snapshot = await db.collection('characters').get();
-  const results: CharacterStatEntry[] = [];
-
-  snapshot.forEach((doc) => {
-    const data = doc.data();
-    if (data.baseStats) {
-      results.push({
-        name: data.name as string,
-        baseStats: data.baseStats as BaseStats,
-      });
-    }
-  });
-
-  return results.sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+  const data = await loadBalanceData();
+  return Object.values(data.characters)
+    .filter((char): char is typeof char & { baseStats: BaseStats } => char.baseStats !== undefined)
+    .map((char) => ({ name: char.name, baseStats: char.baseStats }))
+    .sort((a, b) => a.name.localeCompare(b.name, 'ko'));
 };
 
 export const loadAllStats = unstable_cache(fetchAllStats, ['character-stats'], {

--- a/src/types/patch.ts
+++ b/src/types/patch.ts
@@ -61,6 +61,10 @@ export type Character = {
   name: string;
   stats: CharacterStats;
   patchHistory: PatchEntry[];
+  baseStats?: BaseStats;
+  totalBugCount?: number;
+  bugPatchIds?: number[];
+  releaseDate?: string;
 };
 
 export type BalanceChangesData = {


### PR DESCRIPTION


## 관련 이슈

closes #112

## 변경 사항

- loadAllStats, loadBugRankingData가 직접 Firestore 조회하던 방식을 loadBalanceData() 결과에서 파생하도록 변경.
빌드당 characters 읽기 ~3000 → ~1000으로 감소 예상.

## 변경 유형

- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 기능개선
- [ ] 문서 수정
- [ ] 기타

## 테스트

- [x] 로컬에서 `npm run build` 성공
- [x] 로컬에서 `npm run lint` 통과
- [x] 관련 기능 수동 테스트 완료

## 스크린샷 (UI 변경 시)

## 체크리스트

- [ ] 커밋 메시지가 컨벤션을 따릅니다
- [ ] 코드에 `any` 타입을 사용하지 않았습니다
- [ ] 불필요한 console.log를 제거했습니다
